### PR TITLE
downgrade net46 to net451

### DIFF
--- a/src/WebApiContrib.Core.Concurrency.Redis/project.json
+++ b/src/WebApiContrib.Core.Concurrency.Redis/project.json
@@ -15,7 +15,7 @@
     "defaultNamespace": "WebApiContrib.Core.Concurrency.Redis"
   },
   "frameworks": {
-    "net46": {
+    "net451": {
     },
     "netstandard1.5": {
     }

--- a/src/WebApiContrib.Core.Concurrency.SqlServer/project.json
+++ b/src/WebApiContrib.Core.Concurrency.SqlServer/project.json
@@ -15,7 +15,7 @@
     "defaultNamespace": "WebApiContrib.Core.Concurrency.SqlServer"
   },
   "frameworks": {
-    "net46": {
+    "net451": {
     },
     "netstandard1.5": {
     }

--- a/src/WebApiContrib.Core.Concurrency/project.json
+++ b/src/WebApiContrib.Core.Concurrency/project.json
@@ -22,7 +22,7 @@
     "defaultNamespace": "WebApiContrib.Core.Concurrency"
   },
   "frameworks": {
-    "net46": {
+    "net451": {
       "frameworkAssemblies": {
         "System.Runtime.Serialization": "",
         "System.Runtime": ""

--- a/src/WebApiContrib.Core.Formatter.Bson/project.json
+++ b/src/WebApiContrib.Core.Formatter.Bson/project.json
@@ -15,7 +15,7 @@
     "defaultNamespace": "WebApiContrib.Core.Formatter.Bson"
   },
   "frameworks": {
-    "net46": {
+    "net451": {
     },
     "netstandard1.5": {
     }

--- a/tests/WebApiContrib.Core.Concurrency.Integration.Tests/project.json
+++ b/tests/WebApiContrib.Core.Concurrency.Integration.Tests/project.json
@@ -12,7 +12,7 @@
     "WebApiContrib.Core.Concurrency.Redis": "*"
   },
   "frameworks": {
-    "net46": {
+    "net451": {
       "frameworkAssemblies": {
         "System.Web": "4.0.0.0"
       }

--- a/tests/WebApiContrib.Core.Concurrency.Tests/project.json
+++ b/tests/WebApiContrib.Core.Concurrency.Tests/project.json
@@ -19,7 +19,7 @@
     "System.Runtime.Serialization.Primitives": "4.1.1-*"
   },
   "frameworks": {
-    "net46": {
+    "net451": {
       "frameworkAssemblies": { },
       "dependencies": {
         "Moq": "4.5.9-*",

--- a/tests/WebApiContrib.Core.Formatter.Integration.Tests/project.json
+++ b/tests/WebApiContrib.Core.Formatter.Integration.Tests/project.json
@@ -10,7 +10,7 @@
     "WebApiContrib.Core.Formatter.Bson": "*"
   },
   "frameworks": {
-    "net46": {
+    "net451": {
       "frameworkAssemblies": {
         "System.Web": "4.0.0.0"
       }


### PR DESCRIPTION
Fixes build issues in VS reported in #9 
It also makes sense functionally, because at the time being MVC is compiled for net451 too.

cc @thabart 