### PR TITLE
Added filter overriding capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Current version - **RC2**.
 
 * [WebApiContrib.Core](https://github.com/WebApiContrib/WebAPIContrib.Core/tree/master/src/WebApiContrib.Core)
   * `GlobalRoutePrefixConvention` - `IApplicationModelConvention` allowing you to set a global route prefix
+  * `OverridableFilterProvider` - allows you to override filters from higher scope (i.e. global filters) on lower scope (i.e. controller filters)
 
 ## Formatters
 

--- a/src/WebApiContrib.Core/Filters/OverridableFilterProvider.cs
+++ b/src/WebApiContrib.Core/Filters/OverridableFilterProvider.cs
@@ -1,0 +1,40 @@
+﻿using System.Linq;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace WebApiContrib.Core.Filters
+{
+    public class OverridableFilterProvider : IFilterProvider
+    {
+        public void OnProvidersExecuting(FilterProviderContext context)
+        {
+            if (context.ActionContext.ActionDescriptor.FilterDescriptors != null)
+            {
+                var overrideFilters = context.Results.Where(filterItem => filterItem.Filter is OverrideFilter).ToArray();
+
+                if (overrideFilters.Length > 0)
+                {
+                    for (var i = context.Results.Count - 1; i >= 0; i--)
+                    {
+                        foreach (var overrideFilter in overrideFilters)
+                        {
+                            if (context.Results[i].Descriptor.Filter.GetType() ==
+                                ((OverrideFilter)overrideFilter.Filter).Type &&
+                                context.Results[i].Descriptor.Scope <= overrideFilter.Descriptor.Scope)
+                            {
+                                context.Results.Remove(context.Results[i]);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        public void OnProvidersExecuted(FilterProviderContext context)
+        {
+        }
+
+        //all framework providers have negative orders at -1000, so ours will come later, 
+        //but before user providers which will likely by 0 or higher
+        public int Order => -900;
+    }
+}

--- a/src/WebApiContrib.Core/Filters/OverrideFilter.cs
+++ b/src/WebApiContrib.Core/Filters/OverrideFilter.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace WebApiContrib.Core.Filters
+{
+    public class OverrideFilter : Attribute, IFilterMetadata
+    {
+        public OverrideFilter()
+        {
+        }
+
+        public OverrideFilter(Type type)
+        {
+            Type = type;
+        }
+
+        public Type Type { get; set; }
+    }
+}

--- a/src/WebApiContrib.Core/ServiceCollectionExtensions.cs
+++ b/src/WebApiContrib.Core/ServiceCollectionExtensions.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.DependencyInjection;
+using WebApiContrib.Core.Filters;
+
+namespace WebApiContrib.Core
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static void EnableFilterOverriding(this IServiceCollection services)
+        {
+            services.AddSingleton<IFilterProvider, OverridableFilterProvider>();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #14 

Introduces similar functionality as Web API, allowing you to override filters and effectively punch holes in higher scoped filter pipelines.

For example:

```
    // imagine this filter is registered globally to 403 everything
    public class DenyFilter : ActionFilterAttribute
    {
        public override void OnActionExecuting(ActionExecutingContext context)
        {
            context.Result = new ForbidResult();
        }
    }

    [Route("api/[controller]")]
    public class ValuesController : Controller
    {
        // this returns 403
        [HttpGet]
        public string Get()
        {
            return "value";
        }

        // this returns 200
        [OverrideFilter(typeof(DenyFilter))]
        [HttpGet("{id}")]
        public string Get(int id)
        {
            return "value";
        }
   }
```