### PR TITLE
Added Markdown TagHelper

### DIFF
--- a/WebApiContrib.Core.sln
+++ b/WebApiContrib.Core.sln
@@ -39,6 +39,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "WebApiContrib.Core.Samples"
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "WebApiContrib.Core.Formatter.PlainText", "src\WebApiContrib.Core.Formatter.PlainText\WebApiContrib.Core.Formatter.PlainText.xproj", "{31DA6013-7513-41FC-A5FE-0FB444FBAB9C}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "WebApiContrib.Core.TagHelpers.Markdown", "src\WebApiContrib.Core.TagHelpers.Markdown\WebApiContrib.Core.TagHelpers.Markdown.xproj", "{3EBC421E-AFA7-47F8-B508-80948BBC448A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -93,6 +95,10 @@ Global
 		{31DA6013-7513-41FC-A5FE-0FB444FBAB9C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{31DA6013-7513-41FC-A5FE-0FB444FBAB9C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{31DA6013-7513-41FC-A5FE-0FB444FBAB9C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3EBC421E-AFA7-47F8-B508-80948BBC448A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3EBC421E-AFA7-47F8-B508-80948BBC448A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3EBC421E-AFA7-47F8-B508-80948BBC448A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3EBC421E-AFA7-47F8-B508-80948BBC448A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -112,5 +118,6 @@ Global
 		{CD70A2EC-5A70-4C34-9B89-328F906BEE2B} = {5898776F-DBF8-4C30-85A3-66401B12016F}
 		{8179D011-CED0-40FB-98FA-86326A0F8055} = {EDF687E4-3843-4FB0-9CDC-775E3594D384}
 		{31DA6013-7513-41FC-A5FE-0FB444FBAB9C} = {5898776F-DBF8-4C30-85A3-66401B12016F}
+		{3EBC421E-AFA7-47F8-B508-80948BBC448A} = {5898776F-DBF8-4C30-85A3-66401B12016F}
 	EndGlobalSection
 EndGlobal

--- a/samples/WebApiContrib.Core.Samples/Controllers/MarkdownController.cs
+++ b/samples/WebApiContrib.Core.Samples/Controllers/MarkdownController.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Mvc;
+using WebApiContrib.Core.Samples.Model;
+
+namespace WebApiContrib.Core.Samples.Controllers
+{
+    [Route("[controller]")]
+    public class MarkdownController : Controller
+    {
+        [Route("sample")]
+        public IActionResult Sample()
+        {
+            return View(new SampleMarkdownModel { Heading = "Hello!" });
+        }
+    }
+}

--- a/samples/WebApiContrib.Core.Samples/Model/SampleMarkdownModel.cs
+++ b/samples/WebApiContrib.Core.Samples/Model/SampleMarkdownModel.cs
@@ -1,0 +1,7 @@
+﻿namespace WebApiContrib.Core.Samples.Model
+{
+    public class SampleMarkdownModel
+    {
+        public string Heading { get; set; }
+    }
+}

--- a/samples/WebApiContrib.Core.Samples/Views/Markdown/Sample.cshtml
+++ b/samples/WebApiContrib.Core.Samples/Views/Markdown/Sample.cshtml
@@ -1,0 +1,62 @@
+﻿@*@sample markdown from https://en.wikipedia.org/wiki/Markdown and https://github.com/lunet-io/markdig/tree/master/src/Markdig.Tests/Specs*@
+
+@model WebApiContrib.Core.Samples.Model.SampleMarkdownModel
+
+<md grid-tables="true">
+@Model.Heading
+=======
+Sub-heading
+-----------
+### Another deeper heading
+
+Paragraphs are separated
+by a blank line.
+
+Two spaces at the end of a line leave a
+line break.
+
+Text attributes _italic_, *italic*, __bold__, **bold**, `monospace`.
+
+Horizontal rule:
+
+---
+
+Bullet list:
+
+* apples
+* oranges
+* pears
+
+Numbered list:
+
+1. apples
+2. oranges
+3. pears
+
+A [link](http://example.com).
+
+### Grid table
+
++---------+---------+
+| Header  | Header  |
+| Column1 | Column2 |
++=========+=========+
+| 1. ab   | Hello
+| 3. f    |
++---------+---------+
+| Second row spanning
+| on two columns
++---------+---------+
+| Back    |         |
+| to      |         |
+| one     |         |
+| column  |         | 
+</md>
+
+<md-extended>
+### Extended features: i.e. task lists
+ - [ ] Item1
+ - [x] Item2
+ - [ ] Item3
+ - Item4
+</md-extended>

--- a/samples/WebApiContrib.Core.Samples/Views/_ViewImports.cshtml
+++ b/samples/WebApiContrib.Core.Samples/Views/_ViewImports.cshtml
@@ -1,0 +1,2 @@
+﻿@using WebApiContrib.Core.Samples
+@addTagHelper "*, WebApiContrib.Core.TagHelpers.Markdown"

--- a/samples/WebApiContrib.Core.Samples/project.json
+++ b/samples/WebApiContrib.Core.Samples/project.json
@@ -1,25 +1,34 @@
 ﻿{
-    "dependencies": {
-        "Microsoft.NETCore.App": {
-            "version": "1.0.0-rc2-3002702",
-            "type": "platform"
-        },
-        "Microsoft.AspNetCore.Mvc": "1.0.0-rc2-final",
-        "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-rc2-final",
-        "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-final",
-        "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0-rc2-final",
-        "Microsoft.Extensions.Configuration.FileExtensions": "1.0.0-rc2-final",
-        "Microsoft.Extensions.Configuration.Json": "1.0.0-rc2-final",
-        "Microsoft.Extensions.Logging": "1.0.0-rc2-final",
-        "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-final",
-        "Microsoft.Extensions.Logging.Debug": "1.0.0-rc2-final",
-        "WebApiContrib.Core.Formatter.Csv": "*",
-        "WebApiContrib.Core.Formatter.PlainText": "*",
-        "Microsoft.AspNetCore.StaticFiles": "1.0.0-rc2-final"
+  "dependencies": {
+    "Microsoft.NETCore.App": {
+      "version": "1.0.0-rc2-3002702",
+      "type": "platform"
     },
+    "Microsoft.AspNetCore.Mvc": "1.0.0-rc2-final",
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-rc2-final",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Configuration.FileExtensions": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Configuration.Json": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Logging": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Logging.Debug": "1.0.0-rc2-final",
+    "WebApiContrib.Core.Formatter.Csv": "*",
+    "WebApiContrib.Core.Formatter.PlainText": "*",
+    "Microsoft.AspNetCore.StaticFiles": "1.0.0-rc2-final",
+    "Microsoft.AspNetCore.Razor.Tools": {
+      "version": "1.0.0-preview1-final",
+      "type": "build"
+    },
+    "WebApiContrib.Core.TagHelpers.Markdown": "*"
+  },
 
   "tools": {
     "Microsoft.AspNetCore.Server.IISIntegration.Tools": {
+      "version": "1.0.0-preview1-final",
+      "imports": "portable-net45+win8+dnxcore50"
+    },
+    "Microsoft.AspNetCore.Razor.Tools": {
       "version": "1.0.0-preview1-final",
       "imports": "portable-net45+win8+dnxcore50"
     }

--- a/src/WebApiContrib.Core.TagHelpers.Markdown/MarkdownExtendedTagHelper.cs
+++ b/src/WebApiContrib.Core.TagHelpers.Markdown/MarkdownExtendedTagHelper.cs
@@ -1,0 +1,17 @@
+﻿using System.Threading.Tasks;
+using Markdig;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace WebApiContrib.Core.TagHelpers.Markdown
+{
+    [HtmlTargetElement("md-extended")]
+    public class MarkdownExtendedTagHelper : MarkdownTagHelperBase
+    {
+        private static readonly MarkdownPipeline Pipeline =
+            new MarkdownPipelineBuilder().UseAdvancedExtensions().UseEmojiAndSmiley().Build();
+
+        public override MarkdownPipeline GetPipeline() => Pipeline;
+
+        public override string Name => "md-extended";
+    }
+}

--- a/src/WebApiContrib.Core.TagHelpers.Markdown/MarkdownTagHelper.cs
+++ b/src/WebApiContrib.Core.TagHelpers.Markdown/MarkdownTagHelper.cs
@@ -1,0 +1,46 @@
+﻿using Markdig;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace WebApiContrib.Core.TagHelpers.Markdown
+{
+    [HtmlTargetElement("md")]
+    public class MarkdownTagHelper : MarkdownTagHelperBase
+    {
+        public bool PipeTables { get; set; }
+
+        public bool GridTables { get; set; }
+
+        public bool ExtraEmphasis { get; set; }
+
+        public bool DefinitionLists { get; set; }
+
+        public bool Footnotes { get; set; }
+
+        public bool TaskLists { get; set; }
+
+        public bool ExtraBulletLists { get; set; }
+
+        public bool Abbreviations { get; set; }
+
+        public bool Emoji { get; set; }
+
+        public override MarkdownPipeline GetPipeline()
+        {
+            var pipelineBuilder = new MarkdownPipelineBuilder();
+
+            if (PipeTables) pipelineBuilder = pipelineBuilder.UsePipeTables();
+            if (GridTables) pipelineBuilder = pipelineBuilder.UseGridTables();
+            if (ExtraEmphasis) pipelineBuilder = pipelineBuilder.UseEmphasisExtras();
+            if (DefinitionLists) pipelineBuilder = pipelineBuilder.UseDefinitionLists();
+            if (Footnotes) pipelineBuilder = pipelineBuilder.UseFootnotes();
+            if (TaskLists) pipelineBuilder = pipelineBuilder.UseTaskLists();
+            if (ExtraBulletLists) pipelineBuilder = pipelineBuilder.UseListExtras();
+            if (Abbreviations) pipelineBuilder = pipelineBuilder.UseAbbreviations();
+            if (Emoji) pipelineBuilder = pipelineBuilder.UseEmojiAndSmiley();
+
+            return pipelineBuilder.Build();
+        }
+
+        public override string Name => "md";
+    }
+}

--- a/src/WebApiContrib.Core.TagHelpers.Markdown/MarkdownTagHelperBase.cs
+++ b/src/WebApiContrib.Core.TagHelpers.Markdown/MarkdownTagHelperBase.cs
@@ -1,0 +1,33 @@
+﻿using System.Threading.Tasks;
+using Markdig;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace WebApiContrib.Core.TagHelpers.Markdown
+{
+    public abstract class MarkdownTagHelperBase : TagHelper
+    {
+        public abstract MarkdownPipeline GetPipeline();
+
+        public abstract string Name { get; }
+
+        public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+        {
+            var pipeline = GetPipeline();
+
+            // get rid of the surrounding tag
+            output.TagName = output.TagName != Name ? output.TagName : null;
+            var content = await output.GetChildContentAsync();
+            var markdown = content.GetContent();
+
+            if (!string.IsNullOrWhiteSpace(markdown))
+            {
+                var html = Markdig.Markdown.ToHtml(markdown, pipeline);
+                output.Content.SetHtmlContent(html);
+            }
+            else
+            {
+                output.Content.SetHtmlContent(string.Empty);
+            }
+        }
+    }
+}

--- a/src/WebApiContrib.Core.TagHelpers.Markdown/Properties/AssemblyInfo.cs
+++ b/src/WebApiContrib.Core.TagHelpers.Markdown/Properties/AssemblyInfo.cs
@@ -1,0 +1,19 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("WebApiContrib.Core.TagHelpers.Markdown")]
+[assembly: AssemblyTrademark("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("3ebc421e-afa7-47f8-b508-80948bbc448a")]

--- a/src/WebApiContrib.Core.TagHelpers.Markdown/WebApiContrib.Core.TagHelpers.Markdown.xproj
+++ b/src/WebApiContrib.Core.TagHelpers.Markdown/WebApiContrib.Core.TagHelpers.Markdown.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>3ebc421e-afa7-47f8-b508-80948bbc448a</ProjectGuid>
+    <RootNamespace>WebApiContrib.Core.TagHelpers.Markdown</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/WebApiContrib.Core.TagHelpers.Markdown/markdig-license.txt
+++ b/src/WebApiContrib.Core.TagHelpers.Markdown/markdig-license.txt
@@ -1,0 +1,23 @@
+﻿Copyright (c) 2016, Alexandre Mutel
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification
+, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this 
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, 
+   this list of conditions and the following disclaimer in the documentation 
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/WebApiContrib.Core.TagHelpers.Markdown/project.json
+++ b/src/WebApiContrib.Core.TagHelpers.Markdown/project.json
@@ -1,0 +1,14 @@
+﻿{
+  "version": "1.0.0-*",
+  "dependencies": {
+    "Microsoft.AspNetCore.Mvc.Core": "1.0.0-rc2-final",
+    "Markdig": "0.5.9",
+    "Microsoft.AspNetCore.Razor.Runtime": "1.0.0-rc2-final"
+  },
+  "frameworks": {
+    "net451":  {},
+    "netstandard1.5": {
+      "imports": "dnxcore50"
+    }
+  }
+}

--- a/src/WebApiContrib.Core.TagHelpers.Markdown/project.json
+++ b/src/WebApiContrib.Core.TagHelpers.Markdown/project.json
@@ -1,12 +1,15 @@
 ﻿{
   "version": "1.0.0-*",
+  "buildOptions": {
+    "copyToOutput": [ "markdig-license.txt" ]
+  },
   "dependencies": {
     "Microsoft.AspNetCore.Mvc.Core": "1.0.0-rc2-final",
     "Markdig": "0.5.9",
     "Microsoft.AspNetCore.Razor.Runtime": "1.0.0-rc2-final"
   },
   "frameworks": {
-    "net451":  {},
+    "net451": { },
     "netstandard1.5": {
       "imports": "dnxcore50"
     }


### PR DESCRIPTION
Added a tag helper able to render Markdown into HTML. This can be extremely useful feature when building websites with MVC.

It uses the amazing new Markdown parser called [Markdig](https://github.com/lunet-io/markdig) which beats all other in terms of performance and features.

Most of the features are exposed on the tag helper directly.

## Usage

Typical, with defaults:

```
<md>
@Model.Heading
=======
Sub-heading
-----------
### Another deeper heading

Paragraphs are separated
by a blank line.
</md>
```

Extra features can be enabled via attrbutes:

```
<md grid-tables="true" task-lists="true">
### Grid table

+---------+---------+
| Header  | Header  |
| Column1 | Column2 |
+=========+=========+
| 1. ab   | Hello
| 3. f    |
+---------+---------+

### Task list

 - [ ] Item1
 - [x] Item2
 - [ ] Item3
</md>
```

Finally, all features are enabled by default when using `<md-extended />` tag.