### PR TITLE
Added FromBodyApplicationModelConvention

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Current version - **RC2**.
 ## Main
 
 * [WebApiContrib.Core](https://github.com/WebApiContrib/WebAPIContrib.Core/tree/master/src/WebApiContrib.Core)
-  * `GlobalRoutePrefixConvention` - `IApplicationModelConvention` allowing you to set a global route prefix
+  * `GlobalRoutePrefixConvention` - `IApplicationModelConvention` allowing you to set a global route prefix, which is then combined into all actions
+  * `FromBodyApplicationModelConvention` - `IApplicationModelConvention` allowing you to globally apply body binding source to action parameters. You can also provide predicates to filter on specific controllers, actions or parameters
   * `OverridableFilterProvider` - allows you to override filters from higher scope (i.e. global filters) on lower scope (i.e. controller filters)
   * `ValidationAttribute` - an action filter returning 400 response in case there are any model state errors
 

--- a/samples/WebApiContrib.Core.Samples/Controllers/BindingController.cs
+++ b/samples/WebApiContrib.Core.Samples/Controllers/BindingController.cs
@@ -1,0 +1,16 @@
+using Microsoft.AspNetCore.Mvc;
+using WebApiContrib.Core.Samples.Model;
+
+namespace WebApiContrib.Core.Samples.Controllers
+{
+    [Route("[controller]")]
+    public class BindingController : Controller
+    {
+        [Route("")]
+        [HttpPost]
+        public IActionResult Post(SampleModel model)
+        {
+            return Ok(model);
+        }
+    }
+}

--- a/samples/WebApiContrib.Core.Samples/Model/SampleModel.cs
+++ b/samples/WebApiContrib.Core.Samples/Model/SampleModel.cs
@@ -1,0 +1,7 @@
+namespace WebApiContrib.Core.Samples.Model
+{
+    public class SampleModel
+    {
+        public string Name { get; set; }
+    }
+}

--- a/samples/WebApiContrib.Core.Samples/Startup.cs
+++ b/samples/WebApiContrib.Core.Samples/Startup.cs
@@ -3,8 +3,10 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using WebApiContrib.Core;
 using WebApiContrib.Core.Formatter.Csv;
 using WebApiContrib.Core.Formatter.PlainText;
+using WebApiContrib.Core.Samples.Controllers;
 
 namespace WebApiContrib.Core.Samples
 {
@@ -24,18 +26,11 @@ namespace WebApiContrib.Core.Samples
 
         public void ConfigureServices(IServiceCollection services)
         {
-            //var csvOptions = new CsvFormatterOptions
-            //{
-            //    UseSingleLineHeaderInCsv = true,
-            //    CsvDelimiter = ","
-            //};
-
-            //services.AddMvc()
-            //    .AddCsvSerializerFormatters(csvOptions);
-
-            services.AddMvc()
-                .AddCsvSerializerFormatters()
-                .AddPlainTextFormatters();
+            services.AddMvc(o =>
+            {
+                o.UseFromBodyBinding(controllerPredicate: c => c.ControllerType.AsType() == typeof(BindingController));
+            }).AddCsvSerializerFormatters()
+              .AddPlainTextFormatters();
         }
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)

--- a/samples/WebApiContrib.Core.Samples/project.json
+++ b/samples/WebApiContrib.Core.Samples/project.json
@@ -13,14 +13,15 @@
     "Microsoft.Extensions.Logging": "1.0.0-rc2-final",
     "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-final",
     "Microsoft.Extensions.Logging.Debug": "1.0.0-rc2-final",
-    "WebApiContrib.Core.Formatter.Csv": "*",
-    "WebApiContrib.Core.Formatter.PlainText": "*",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0-rc2-final",
     "Microsoft.AspNetCore.Razor.Tools": {
       "version": "1.0.0-preview1-final",
       "type": "build"
     },
-    "WebApiContrib.Core.TagHelpers.Markdown": "*"
+    "WebApiContrib.Core.Formatter.Csv": "*",
+    "WebApiContrib.Core.Formatter.PlainText": "*",
+    "WebApiContrib.Core.TagHelpers.Markdown": "*",
+    "WebApiContrib.Core": "*"
   },
 
   "tools": {

--- a/src/WebApiContrib.Core/Binding/FromBodyApplicationModelConvention.cs
+++ b/src/WebApiContrib.Core/Binding/FromBodyApplicationModelConvention.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using WebApiContrib.Core.Internal;
+
+namespace WebApiContrib.Core.Binding
+{
+    public class FromBodyApplicationModelConvention : IApplicationModelConvention
+    {
+        private readonly Func<ControllerModel, bool> _controllerPredicate;
+        private readonly Func<ActionModel, bool> _actionPredicate;
+        private readonly Func<ParameterModel, bool> _parameterPredicate;
+
+        public FromBodyApplicationModelConvention() : this(null, null, null)
+        {
+        }
+
+        public FromBodyApplicationModelConvention(Func<ControllerModel, bool> controllerPredicate, 
+            Func<ActionModel, bool> actionPredicate, Func<ParameterModel, bool> parameterPredicate)
+        {
+            _controllerPredicate = controllerPredicate ?? (c => true);
+            _actionPredicate = actionPredicate ?? (a => true);
+            _parameterPredicate = parameterPredicate ?? (p => true);
+        }
+
+        public void Apply(ApplicationModel application)
+        {
+            foreach (var controller in application.Controllers.Where(_controllerPredicate))
+            {
+                foreach (var action in controller.Actions.Where(_actionPredicate))
+                {
+                    foreach (var parameter in action.Parameters.Where(parameter => parameter.BindingInfo?.BindingSource == null &&
+                            !parameter.Attributes.OfType<IBindingSourceMetadata>().Any() &&
+                            !parameter.ParameterInfo.ParameterType.CanBeConvertedFromString()).Where(_parameterPredicate))
+                    {
+                        parameter.BindingInfo = parameter.BindingInfo ?? new BindingInfo();
+                        parameter.BindingInfo.BindingSource = BindingSource.Body;
+                    }
+                }
+            }
+        }
+
+
+
+
+    }
+}

--- a/src/WebApiContrib.Core/Internal/TypeExtensions.cs
+++ b/src/WebApiContrib.Core/Internal/TypeExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.ComponentModel;
+using System.Reflection;
+
+namespace WebApiContrib.Core.Internal
+{
+    public static class TypeExtensions
+    {
+        public static bool CanBeConvertedFromString(this Type type)
+        {
+            type = Nullable.GetUnderlyingType(type) ?? type;
+            return type.GetTypeInfo().IsPrimitive ||
+                   type == typeof(string) ||
+                   type == typeof(DateTime) ||
+                   type == typeof(DateTimeOffset) ||
+                   Convert.GetTypeCode(type) != TypeCode.Object ||
+                   TypeDescriptor.GetConverter(type).CanConvertFrom(typeof(string));
+        }
+    }
+}

--- a/src/WebApiContrib.Core/MvcOptionsExtensions.cs
+++ b/src/WebApiContrib.Core/MvcOptionsExtensions.cs
@@ -1,5 +1,8 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
 using Microsoft.AspNetCore.Mvc.Routing;
+using WebApiContrib.Core.Binding;
 using WebApiContrib.Core.Routing;
 
 namespace WebApiContrib.Core
@@ -9,6 +12,12 @@ namespace WebApiContrib.Core
         public static void UseGlobalRoutePrefix(this MvcOptions opts, IRouteTemplateProvider routeAttribute)
         {
             opts.Conventions.Insert(0, new GlobalRoutePrefixConvention(routeAttribute));
+        }
+
+        public static void UseFromBodyBinding(this MvcOptions opts, Func<ControllerModel, bool> controllerPredicate = null,
+            Func<ActionModel, bool> actionPredicate = null, Func<ParameterModel, bool> parameterPredicate = null)
+        {
+            opts.Conventions.Insert(0, new FromBodyApplicationModelConvention(controllerPredicate, actionPredicate, parameterPredicate));
         }
     }
 }


### PR DESCRIPTION
Out of the box MVC does not support binding parameters from body - instead you have to decorate them with `[FromBody]` attribute:

```
        [Route("")]
        [HttpPost]
        public IActionResult Post([FromBody]SampleModel model)
        {
            return Ok(model);
        }
```

This PR introduces a convention that automatically applies the body binding source across all your complex action parameters (effectivelly restoring Web API default behavior). 

```
        public void ConfigureServices(IServiceCollection services)
        {
            services.AddMvc(o =>
            {
                o.UseFromBodyBinding();
            });
        }
```

You can also pass predicates determining which controllers, actions or parameters the convention should be applied to.

For example:

```
        public void ConfigureServices(IServiceCollection services)
        {
            services.AddMvc(o =>
            {
                o.UseFromBodyBinding(controllerPredicate: c => c.ControllerType.IsAssignableFrom(typeof(MyBaseController));
            });
        }
```