### PR TITLE
Added WebPages

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ WebAPIContrib.Core is a collection of open source projects, add-ons and extensio
 ## TagHelpers
 * [WebApiContrib.Core.TagHelpers.Markdown](https://github.com/WebApiContrib/WebAPIContrib.Core/tree/master/src/WebApiContrib.Core.TagHelpers.Markdown)
 
+## WebPages
+* [WebApiContrib.Core.WebPages](https://github.com/WebApiContrib/WebAPIContrib.Core/tree/master/src/WebApiContrib.Core.WebPages)
+
+A project allowing you to create Razor web pages without any controller/action infrastructure. Just add a `Views/MyPage.cshtml` and you can now navigate to `<server root>/MyPage` in the browser. Supports the typical Razor constructs - inline C# code, `@inject` etc.
+
 ## Other
 
 * [WebApiContrib.Core.Concurrency](https://github.com/WebApiContrib/WebAPIContrib.Core/tree/master/src/WebApiContrib.Core.Concurrency)

--- a/WebApiContrib.Core.sln
+++ b/WebApiContrib.Core.sln
@@ -45,6 +45,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "WebApiContrib.Core.Formatte
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "WebApiContrib.Core.Samples.Formatter.Jsonp.JQueryClient", "samples\WebApiContrib.Core.Samples.Formatter.Jsonp.JQueryClient\WebApiContrib.Core.Samples.Formatter.Jsonp.JQueryClient.xproj", "{5A3DF1EA-4553-4370-8CD2-6C341CA80755}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "WebApiContrib.Core.WebPages", "src\WebApiContrib.Core.WebPages\WebApiContrib.Core.WebPages.xproj", "{720B3330-2C57-4D67-9D84-5DC76412F169}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -111,6 +113,10 @@ Global
 		{5A3DF1EA-4553-4370-8CD2-6C341CA80755}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5A3DF1EA-4553-4370-8CD2-6C341CA80755}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5A3DF1EA-4553-4370-8CD2-6C341CA80755}.Release|Any CPU.Build.0 = Release|Any CPU
+		{720B3330-2C57-4D67-9D84-5DC76412F169}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{720B3330-2C57-4D67-9D84-5DC76412F169}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{720B3330-2C57-4D67-9D84-5DC76412F169}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{720B3330-2C57-4D67-9D84-5DC76412F169}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -133,5 +139,6 @@ Global
 		{3EBC421E-AFA7-47F8-B508-80948BBC448A} = {5898776F-DBF8-4C30-85A3-66401B12016F}
 		{CD1A5F8F-8468-4EF1-8B3C-EF05420F43EB} = {5898776F-DBF8-4C30-85A3-66401B12016F}
 		{5A3DF1EA-4553-4370-8CD2-6C341CA80755} = {EDF687E4-3843-4FB0-9CDC-775E3594D384}
+		{720B3330-2C57-4D67-9D84-5DC76412F169} = {5898776F-DBF8-4C30-85A3-66401B12016F}
 	EndGlobalSection
 EndGlobal

--- a/WebApiContrib.Core.sln
+++ b/WebApiContrib.Core.sln
@@ -47,6 +47,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "WebApiContrib.Core.Samples.
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "WebApiContrib.Core.WebPages", "src\WebApiContrib.Core.WebPages\WebApiContrib.Core.WebPages.xproj", "{720B3330-2C57-4D67-9D84-5DC76412F169}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "WebApiContrib.Core.WebPages.Samples", "samples\WebApiContrib.Core.WebPages.Samples\WebApiContrib.Core.WebPages.Samples.xproj", "{F9AE291E-A6BD-4F53-A73F-678FE0D5BF72}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -117,6 +119,10 @@ Global
 		{720B3330-2C57-4D67-9D84-5DC76412F169}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{720B3330-2C57-4D67-9D84-5DC76412F169}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{720B3330-2C57-4D67-9D84-5DC76412F169}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F9AE291E-A6BD-4F53-A73F-678FE0D5BF72}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F9AE291E-A6BD-4F53-A73F-678FE0D5BF72}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F9AE291E-A6BD-4F53-A73F-678FE0D5BF72}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F9AE291E-A6BD-4F53-A73F-678FE0D5BF72}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -140,5 +146,6 @@ Global
 		{CD1A5F8F-8468-4EF1-8B3C-EF05420F43EB} = {5898776F-DBF8-4C30-85A3-66401B12016F}
 		{5A3DF1EA-4553-4370-8CD2-6C341CA80755} = {EDF687E4-3843-4FB0-9CDC-775E3594D384}
 		{720B3330-2C57-4D67-9D84-5DC76412F169} = {5898776F-DBF8-4C30-85A3-66401B12016F}
+		{F9AE291E-A6BD-4F53-A73F-678FE0D5BF72} = {EDF687E4-3843-4FB0-9CDC-775E3594D384}
 	EndGlobalSection
 EndGlobal

--- a/samples/WebApiContrib.Core.WebPages.Samples/Program.cs
+++ b/samples/WebApiContrib.Core.WebPages.Samples/Program.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+
+namespace WebApiContrib.Core.WebPages.Samples
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            var host = new WebHostBuilder()
+                .UseKestrel()
+                .UseContentRoot(Directory.GetCurrentDirectory())
+                .UseIISIntegration()
+                .UseStartup<Startup>()
+                .Build();
+
+            host.Run();
+        }
+    }
+}

--- a/samples/WebApiContrib.Core.WebPages.Samples/Properties/launchSettings.json
+++ b/samples/WebApiContrib.Core.WebPages.Samples/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:42338/RazorSample",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "WebApiContrib.Core.WebPages.Samples": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "launchUrl": "http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/samples/WebApiContrib.Core.WebPages.Samples/Startup.cs
+++ b/samples/WebApiContrib.Core.WebPages.Samples/Startup.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using WebApiContrib.Core.WebPages;
+
+namespace WebApiContrib.Core.WebPages.Samples
+{
+    public class Startup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddWebPages();
+        }
+
+        public void Configure(IApplicationBuilder app)
+        {
+            app.UseWebPages();
+        }
+    }
+}

--- a/samples/WebApiContrib.Core.WebPages.Samples/Views/OtherPage.cshtml
+++ b/samples/WebApiContrib.Core.WebPages.Samples/Views/OtherPage.cshtml
@@ -1,0 +1,16 @@
+﻿@{
+    var hello = "hello from other page";
+}
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Other page</title>
+</head>
+<body>
+    <h1>@hello!!!!</h1>
+    <div>
+        <a href="/RazorSample">Click here to go to a more elaborate Razor sample</a>
+    </div>
+</body>
+</html>

--- a/samples/WebApiContrib.Core.WebPages.Samples/Views/RazorSample.cshtml
+++ b/samples/WebApiContrib.Core.WebPages.Samples/Views/RazorSample.cshtml
@@ -1,0 +1,63 @@
+﻿@inject Microsoft.AspNetCore.Hosting.IHostingEnvironment env
+
+@{
+  // Working with numbers
+  var a = 4;
+  var b = 5;
+  var theSum = a + b;
+
+  // Working with characters (strings)
+  var technology = "ASP.NET";
+  var product = "Web Pages";
+
+  // Working with objects
+  var rightNow = DateTime.Now;
+}
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Testing Razor Syntax</title>
+  <meta charset="utf-8" />
+  <style>
+      body {
+          font-family: Verdana;
+          margin-left: 50px;
+          margin-top: 50px;
+      }
+
+      div {
+          border: 1px solid black;
+          width: 50%;
+          margin: 1.2em;
+          padding: 1em;
+      }
+
+      span.bright {
+          color: red;
+      }
+  </style>
+</head>
+<body>
+  <h1>Testing Razor Syntax</h1>
+  <form method="post">
+      <div>
+          <p>The value of <em>a</em> is @a.  The value of <em>b</em> is @b.
+          <p>The sum of <em>a</em> and <em>b</em> is <strong>@theSum</strong>.</p>
+          <p>The product of <em>a</em> and <em>b</em> is <strong>@(a * b)</strong>.</p>
+      </div>
+      <div>
+          <p>The technology is @technology, and the product is @product.</p>
+          <p>Together they are <span class="bright">@(technology + " " + product)</span></p>
+      </div>
+      <div>
+          <p>The current date and time is: @rightNow</p>
+          <p>The URL of the current page path is<br /><br /><code>@Context.Request.Path</code></p>
+          <p>The app web root path is<br /><br /><code>@env.WebRootPath</code></p>
+      </div>
+      <div>
+          <a href="/OtherPage">Click here to go to the other page!</a>
+      </div>
+  </form>
+</body>
+</html>

--- a/samples/WebApiContrib.Core.WebPages.Samples/WebApiContrib.Core.WebPages.Samples.xproj
+++ b/samples/WebApiContrib.Core.WebPages.Samples/WebApiContrib.Core.WebPages.Samples.xproj
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>f9ae291e-a6bd-4f53-a73f-678fe0d5bf72</ProjectGuid>
+    <RootNamespace>WebApiContrib.Core.WebPages.Samples</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <DnxInvisibleContent Include="bower.json" />
+    <DnxInvisibleContent Include=".bowerrc" />
+    <DnxInvisibleContent Include="package.json" />
+    <DnxInvisibleContent Include=".npmrc" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\DotNet.Web\Microsoft.DotNet.Web.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/samples/WebApiContrib.Core.WebPages.Samples/project.json
+++ b/samples/WebApiContrib.Core.WebPages.Samples/project.json
@@ -1,0 +1,67 @@
+﻿{
+  "dependencies": {
+    "Microsoft.NETCore.App": {
+      "version": "1.0.0",
+      "type": "platform"
+    },
+    "Microsoft.AspNetCore.Mvc": "1.0.0",
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
+    "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0",
+    "Microsoft.Extensions.Configuration.FileExtensions": "1.0.0",
+    "Microsoft.Extensions.Configuration.Json": "1.0.0",
+    "Microsoft.Extensions.Logging": "1.0.0",
+    "Microsoft.Extensions.Logging.Console": "1.0.0",
+    "Microsoft.Extensions.Logging.Debug": "1.0.0",
+    "Microsoft.AspNetCore.Diagnostics": "1.0.0",
+    "Microsoft.AspNetCore.StaticFiles": "1.0.0",
+    "Microsoft.AspNetCore.Razor.Tools": {
+      "version": "1.0.0-preview2-final",
+      "type": "build"
+    },
+    "WebApiContrib.Core.WebPages": "*"
+  },
+
+  "tools": {
+    "Microsoft.AspNetCore.Server.IISIntegration.Tools": {
+      "version": "1.0.0-preview2-final",
+      "imports": "portable-net45+win8+dnxcore50"
+    },
+    "Microsoft.AspNetCore.Razor.Tools": {
+      "version": "1.0.0-preview2-final",
+      "imports": "portable-net45+win8+dnxcore50"
+    }
+  },
+
+  "frameworks": {
+    "netcoreapp1.0": {
+      "imports": [
+        "dotnet5.6",
+        "dnxcore50",
+        "portable-net45+win8"
+      ]
+    }
+  },
+
+  "buildOptions": {
+    "emitEntryPoint": true,
+    "preserveCompilationContext": true
+  },
+
+  "runtimeOptions": {
+    "gcServer": true
+  },
+
+  "publishOptions": {
+    "include": [
+      "wwwroot",
+      "Views",
+      "appsettings.json",
+      "web.config"
+    ]
+  },
+
+  "scripts": {
+    "postpublish": [ "dotnet publish-iis --publish-folder %publish:OutputPath% --framework %publish:FullTargetFramework%" ]
+  }
+}

--- a/samples/WebApiContrib.Core.WebPages.Samples/web.config
+++ b/samples/WebApiContrib.Core.WebPages.Samples/web.config
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+
+  <!--
+    Configure your application settings in appsettings.json. Learn more at http://go.microsoft.com/fwlink/?LinkId=786380
+  -->
+
+  <system.webServer>
+    <handlers>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified"/>
+    </handlers>
+    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false"/>
+  </system.webServer>
+</configuration>

--- a/src/WebApiContrib.Core.WebPages/Properties/AssemblyInfo.cs
+++ b/src/WebApiContrib.Core.WebPages/Properties/AssemblyInfo.cs
@@ -1,0 +1,19 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("WebApiContrib.Core.WebPages")]
+[assembly: AssemblyTrademark("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("720b3330-2c57-4d67-9d84-5dc76412f169")]

--- a/src/WebApiContrib.Core.WebPages/RazorViewToStringRenderer.cs
+++ b/src/WebApiContrib.Core.WebPages/RazorViewToStringRenderer.cs
@@ -8,62 +8,72 @@ using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using System;
+using System.Diagnostics;
 using System.IO;
 
 namespace WebApiContrib.Core.WebPages
 {
+    //public class WebPagesRazorViewEngine : RazorViewEngine
+    //{
+    //    override 
+    //}
+
     public class RazorViewToStringRenderer
     {
         private IRazorViewEngine _viewEngine;
         private ITempDataProvider _tempDataProvider;
         private IServiceProvider _serviceProvider;
-        private IHttpContextAccessor _contextAccessor;
 
-        public RazorViewToStringRenderer(
-            IRazorViewEngine viewEngine,
-            ITempDataProvider tempDataProvider,
-            IServiceProvider serviceProvider,
-            IHttpContextAccessor contextAccessor)
+        public RazorViewToStringRenderer(IRazorViewEngine viewEngine, ITempDataProvider tempDataProvider,
+            IServiceProvider serviceProvider)
         {
             _viewEngine = viewEngine;
             _tempDataProvider = tempDataProvider;
             _serviceProvider = serviceProvider;
-            _contextAccessor = contextAccessor;
         }
 
         public string RenderViewToString(string path)
         {
             var actionContext = GetActionContext();
-            var viewEngineResult = _viewEngine.FindView(actionContext, path, isMainPage: true);
-
-            if (!viewEngineResult.Success)
+            try
             {
-                throw new InvalidOperationException(string.Format("Couldn't find view '{0}'", path));
+                var viewEngineResult = _viewEngine.FindView(actionContext, path, isMainPage: false);
+
+                if (!viewEngineResult.Success)
+                {
+                    throw new InvalidOperationException(string.Format("Couldn't find view '{0}'", path));
+                }
+
+                var view = viewEngineResult.View;
+                using (var output = new StringWriter())
+                {
+                    var viewContext = new ViewContext(
+                        actionContext,
+                        view,
+                        new ViewDataDictionary(
+                            metadataProvider: new EmptyModelMetadataProvider(),
+                            modelState: new ModelStateDictionary())
+                        { },
+                        new TempDataDictionary(actionContext.HttpContext, _tempDataProvider),
+                        output,
+                        new HtmlHelperOptions());
+
+                    view.RenderAsync(viewContext).GetAwaiter().GetResult();
+                    return output.ToString();
+                }
             }
-
-            var view = viewEngineResult.View;
-            using (var output = new StringWriter())
+            catch (Exception e)
             {
-                var viewContext = new ViewContext(
-                    actionContext,
-                    view,
-                    new ViewDataDictionary(
-                        metadataProvider: new EmptyModelMetadataProvider(),
-                        modelState: new ModelStateDictionary())
-                    {},
-                    new TempDataDictionary(actionContext.HttpContext, _tempDataProvider),
-                    output,
-                    new HtmlHelperOptions());
-
-                view.RenderAsync(viewContext).GetAwaiter().GetResult();
-                return output.ToString();
+                Debug.WriteLine(e.Message);
+                throw;
             }
         }
 
         private ActionContext GetActionContext()
         {
-            _contextAccessor.HttpContext.RequestServices = _serviceProvider;
-            return new ActionContext(_contextAccessor.HttpContext, new RouteData(), new ActionDescriptor());
+            var httpContext = new DefaultHttpContext();
+            httpContext.RequestServices = _serviceProvider;
+            return new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
         }
     }
 }

--- a/src/WebApiContrib.Core.WebPages/RazorViewToStringRenderer.cs
+++ b/src/WebApiContrib.Core.WebPages/RazorViewToStringRenderer.cs
@@ -1,0 +1,69 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.Razor;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.IO;
+
+namespace WebApiContrib.Core.WebPages
+{
+    public class RazorViewToStringRenderer
+    {
+        private IRazorViewEngine _viewEngine;
+        private ITempDataProvider _tempDataProvider;
+        private IServiceProvider _serviceProvider;
+        private IHttpContextAccessor _contextAccessor;
+
+        public RazorViewToStringRenderer(
+            IRazorViewEngine viewEngine,
+            ITempDataProvider tempDataProvider,
+            IServiceProvider serviceProvider,
+            IHttpContextAccessor contextAccessor)
+        {
+            _viewEngine = viewEngine;
+            _tempDataProvider = tempDataProvider;
+            _serviceProvider = serviceProvider;
+            _contextAccessor = contextAccessor;
+        }
+
+        public string RenderViewToString(string path)
+        {
+            var actionContext = GetActionContext();
+            var viewEngineResult = _viewEngine.FindView(actionContext, path, isMainPage: true);
+
+            if (!viewEngineResult.Success)
+            {
+                throw new InvalidOperationException(string.Format("Couldn't find view '{0}'", path));
+            }
+
+            var view = viewEngineResult.View;
+            using (var output = new StringWriter())
+            {
+                var viewContext = new ViewContext(
+                    actionContext,
+                    view,
+                    new ViewDataDictionary(
+                        metadataProvider: new EmptyModelMetadataProvider(),
+                        modelState: new ModelStateDictionary())
+                    {},
+                    new TempDataDictionary(actionContext.HttpContext, _tempDataProvider),
+                    output,
+                    new HtmlHelperOptions());
+
+                view.RenderAsync(viewContext).GetAwaiter().GetResult();
+                return output.ToString();
+            }
+        }
+
+        private ActionContext GetActionContext()
+        {
+            _contextAccessor.HttpContext.RequestServices = _serviceProvider;
+            return new ActionContext(_contextAccessor.HttpContext, new RouteData(), new ActionDescriptor());
+        }
+    }
+}

--- a/src/WebApiContrib.Core.WebPages/RazorViewToStringRenderer.cs
+++ b/src/WebApiContrib.Core.WebPages/RazorViewToStringRenderer.cs
@@ -13,11 +13,7 @@ using System.IO;
 
 namespace WebApiContrib.Core.WebPages
 {
-    //public class WebPagesRazorViewEngine : RazorViewEngine
-    //{
-    //    override 
-    //}
-
+    // adapted, with Imran's permission, from https://weblogs.asp.net/imranbaloch/adding-web-pages-in-aspnet-core
     public class RazorViewToStringRenderer
     {
         private IRazorViewEngine _viewEngine;

--- a/src/WebApiContrib.Core.WebPages/WebApiContrib.Core.WebPages.xproj
+++ b/src/WebApiContrib.Core.WebPages/WebApiContrib.Core.WebPages.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>720b3330-2c57-4d67-9d84-5dc76412f169</ProjectGuid>
+    <RootNamespace>WebApiContrib.Core.WebPages</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/WebApiContrib.Core.WebPages/WebPagesApplicationBuilderExtensions.cs
+++ b/src/WebApiContrib.Core.WebPages/WebPagesApplicationBuilderExtensions.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Hosting;
+
+namespace WebApiContrib.Core.WebPages
+{
+    public static class WebPagesApplicationBuilderExtensions
+    {
+        public static IApplicationBuilder UseWebPages(this IApplicationBuilder app)
+        {
+            var renderer = app.ApplicationServices.GetRequiredService<RazorViewToStringRenderer>();
+            var hostingEnvironment = app.ApplicationServices.GetRequiredService<IHostingEnvironment>();
+            return app.UseRouter(new WebPagesRouter(hostingEnvironment, renderer));
+        }
+    }
+}

--- a/src/WebApiContrib.Core.WebPages/WebPagesRouter.cs
+++ b/src/WebApiContrib.Core.WebPages/WebPagesRouter.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 
 namespace WebApiContrib.Core.WebPages
 {
+    // adapted, with Imran's permission, from https://weblogs.asp.net/imranbaloch/adding-web-pages-in-aspnet-core
     public class WebPagesRouter : IRouter
     {
         private IHostingEnvironment _hostingEnvironment;

--- a/src/WebApiContrib.Core.WebPages/WebPagesRouter.cs
+++ b/src/WebApiContrib.Core.WebPages/WebPagesRouter.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace WebApiContrib.Core.WebPages
+{
+    public class WebPagesRouter : IRouter
+    {
+        private IHostingEnvironment _hostingEnvironment;
+        private RazorViewToStringRenderer _renderer;
+
+        public WebPagesRouter(IHostingEnvironment hostingEnvironment, RazorViewToStringRenderer renderer)
+        {
+            _hostingEnvironment = hostingEnvironment;
+            _renderer = renderer;
+        }
+
+        public VirtualPathData GetVirtualPath(VirtualPathContext context)
+        {
+            return null;
+        }
+
+        public async Task RouteAsync(RouteContext context)
+        {
+            var path = context.HttpContext.Request.Path.ToString().TrimStart('/');
+
+            if (Regex.IsMatch(path, "^([\\w]+/)*[\\w]+[.]cshtml$"))
+            {
+                var filePath = Path.Combine(_hostingEnvironment.ContentRootPath, path);
+
+                //context.IsHandled = true;
+                if (!File.Exists(filePath))
+                {
+                    context.HttpContext.Response.StatusCode = 404;
+                    return;
+                }
+
+                var contents = _renderer.RenderViewToString("~/" + path);
+                await context.HttpContext.Response.WriteAsync(contents);
+            }
+        }
+    }
+}

--- a/src/WebApiContrib.Core.WebPages/WebPagesRouter.cs
+++ b/src/WebApiContrib.Core.WebPages/WebPagesRouter.cs
@@ -28,20 +28,19 @@ namespace WebApiContrib.Core.WebPages
 
         public async Task RouteAsync(RouteContext context)
         {
-            var path = context.HttpContext.Request.Path.ToString().TrimStart('/');
+            var path = context.HttpContext.Request.Path.ToString().TrimStart('/').TrimEnd('/');
 
-            if (Regex.IsMatch(path, "^([\\w]+/)*[\\w]+[.]cshtml$"))
+            // if path doesn't have an extension, we want to probe it for being a page
+            if (!path.Contains("."))
             {
-                var filePath = Path.Combine(_hostingEnvironment.ContentRootPath, path);
-
-                //context.IsHandled = true;
+                var filePath = Path.Combine(_hostingEnvironment.ContentRootPath, "Views", path + ".cshtml");
                 if (!File.Exists(filePath))
                 {
                     context.HttpContext.Response.StatusCode = 404;
                     return;
                 }
 
-                var contents = _renderer.RenderViewToString("~/" + path);
+                var contents = _renderer.RenderViewToString(path);
                 await context.HttpContext.Response.WriteAsync(contents);
             }
         }

--- a/src/WebApiContrib.Core.WebPages/WebPagesServiceCollectionExtensions.cs
+++ b/src/WebApiContrib.Core.WebPages/WebPagesServiceCollectionExtensions.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace WebApiContrib.Core.WebPages
+{
+    public static class WebPagesServiceCollectionExtensions
+    {
+        public static void AddWebPages(this IServiceCollection services)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+            services.AddSingleton<RazorViewToStringRenderer>();
+        }
+    }
+}

--- a/src/WebApiContrib.Core.WebPages/WebPagesServiceCollectionExtensions.cs
+++ b/src/WebApiContrib.Core.WebPages/WebPagesServiceCollectionExtensions.cs
@@ -1,4 +1,10 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Razor;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.PlatformAbstractions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -14,6 +20,12 @@ namespace WebApiContrib.Core.WebPages
             {
                 throw new ArgumentNullException(nameof(services));
             }
+
+            services.AddMvcCore().AddRazorViewEngine(o =>
+            {
+                o.ViewLocationFormats.Clear();
+                o.ViewLocationFormats.Add("/Views/{0}" + RazorViewEngine.ViewExtension);
+            });
             services.AddSingleton<RazorViewToStringRenderer>();
         }
     }

--- a/src/WebApiContrib.Core.WebPages/project.json
+++ b/src/WebApiContrib.Core.WebPages/project.json
@@ -1,0 +1,14 @@
+﻿{
+  "version": "1.0.0-*",
+  "dependencies": {
+    "Microsoft.AspNetCore.Mvc.Core": "1.0.0",
+    "Microsoft.AspNetCore.Mvc.ViewFeatures": "1.0.0",
+    "Microsoft.AspNetCore.Mvc.Razor": "1.0.0"
+  },
+  "frameworks": {
+    "net451":  {},
+    "netstandard1.6": {
+      "imports": "dnxcore50"
+    }
+  }
+}


### PR DESCRIPTION
With Imran's permission, adapted and updated to RTM from [his blog post](https://weblogs.asp.net/imranbaloch/adding-web-pages-in-aspnet-core).

Allows us to create Razor views (with full Razor semantics) and use those as Web Pages, without a need for any controller or action.

This is right now a simple implementation, but we can build around it and make it really cool down the road. Fairly equivalent to the old ASP NET Web Pages, which are missing from ASP.NET Core

cc: @jglozano @panesofglass 