### PR TITLE
added support for rootviewname

### DIFF
--- a/samples/WebApiContrib.Core.WebPages.Samples/Startup.cs
+++ b/samples/WebApiContrib.Core.WebPages.Samples/Startup.cs
@@ -19,7 +19,7 @@ namespace WebApiContrib.Core.WebPages.Samples
 
         public void Configure(IApplicationBuilder app)
         {
-            app.UseWebPages();
+            app.UseWebPages(rootViewName: "RazorSample");
         }
     }
 }

--- a/src/WebApiContrib.Core.WebPages/RazorViewToStringRenderer.cs
+++ b/src/WebApiContrib.Core.WebPages/RazorViewToStringRenderer.cs
@@ -16,9 +16,9 @@ namespace WebApiContrib.Core.WebPages
     // adapted, with Imran's permission, from https://weblogs.asp.net/imranbaloch/adding-web-pages-in-aspnet-core
     public class RazorViewToStringRenderer
     {
-        private IRazorViewEngine _viewEngine;
-        private ITempDataProvider _tempDataProvider;
-        private IServiceProvider _serviceProvider;
+        private readonly IRazorViewEngine _viewEngine;
+        private readonly ITempDataProvider _tempDataProvider;
+        private readonly IServiceProvider _serviceProvider;
 
         public RazorViewToStringRenderer(IRazorViewEngine viewEngine, ITempDataProvider tempDataProvider,
             IServiceProvider serviceProvider)
@@ -37,7 +37,7 @@ namespace WebApiContrib.Core.WebPages
 
                 if (!viewEngineResult.Success)
                 {
-                    throw new InvalidOperationException(string.Format("Couldn't find view '{0}'", path));
+                    throw new InvalidOperationException($"Couldn't find view '{path}'");
                 }
 
                 var view = viewEngineResult.View;
@@ -67,8 +67,7 @@ namespace WebApiContrib.Core.WebPages
 
         private ActionContext GetActionContext()
         {
-            var httpContext = new DefaultHttpContext();
-            httpContext.RequestServices = _serviceProvider;
+            var httpContext = new DefaultHttpContext {RequestServices = _serviceProvider};
             return new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
         }
     }

--- a/src/WebApiContrib.Core.WebPages/WebPagesApplicationBuilderExtensions.cs
+++ b/src/WebApiContrib.Core.WebPages/WebPagesApplicationBuilderExtensions.cs
@@ -6,11 +6,11 @@ namespace WebApiContrib.Core.WebPages
 {
     public static class WebPagesApplicationBuilderExtensions
     {
-        public static IApplicationBuilder UseWebPages(this IApplicationBuilder app)
+        public static IApplicationBuilder UseWebPages(this IApplicationBuilder app, string rootViewName = null)
         {
             var renderer = app.ApplicationServices.GetRequiredService<RazorViewToStringRenderer>();
             var hostingEnvironment = app.ApplicationServices.GetRequiredService<IHostingEnvironment>();
-            return app.UseRouter(new WebPagesRouter(hostingEnvironment, renderer));
+            return app.UseRouter(new WebPagesRouter(hostingEnvironment, renderer, rootViewName));
         }
     }
 }

--- a/src/WebApiContrib.Core.WebPages/WebPagesRouter.cs
+++ b/src/WebApiContrib.Core.WebPages/WebPagesRouter.cs
@@ -13,13 +13,15 @@ namespace WebApiContrib.Core.WebPages
     // adapted, with Imran's permission, from https://weblogs.asp.net/imranbaloch/adding-web-pages-in-aspnet-core
     public class WebPagesRouter : IRouter
     {
-        private IHostingEnvironment _hostingEnvironment;
-        private RazorViewToStringRenderer _renderer;
+        private readonly IHostingEnvironment _hostingEnvironment;
+        private readonly RazorViewToStringRenderer _renderer;
+        private readonly string _rootViewName;
 
-        public WebPagesRouter(IHostingEnvironment hostingEnvironment, RazorViewToStringRenderer renderer)
+        public WebPagesRouter(IHostingEnvironment hostingEnvironment, RazorViewToStringRenderer renderer, string rootViewName)
         {
             _hostingEnvironment = hostingEnvironment;
             _renderer = renderer;
+            _rootViewName = rootViewName;
         }
 
         public VirtualPathData GetVirtualPath(VirtualPathContext context)
@@ -31,8 +33,13 @@ namespace WebApiContrib.Core.WebPages
         {
             var path = context.HttpContext.Request.Path.ToString().TrimStart('/').TrimEnd('/');
 
-            // if path doesn't have an extension, we want to probe it for being a page
-            if (!path.Contains("."))
+            // root
+            if (path == string.Empty && _rootViewName != null)
+            {
+                path = _rootViewName;
+            }
+
+            if (!path.Contains(".")) // if path doesn't have an extension, we want to probe it for being a page
             {
                 var filePath = Path.Combine(_hostingEnvironment.ContentRootPath, "Views", path + ".cshtml");
                 if (!File.Exists(filePath))


### PR DESCRIPTION
Fixes #35 

We can now say:

```csharp
        public void Configure(IApplicationBuilder app)
        {
            app.UseWebPages(rootViewName: "RazorSample");
        }
```

And this means that `~/Views/RazorSample.cshtml` will be used when the user navigates to server root.