### PR TITLE
added IsAjaxRequest

### DIFF
--- a/src/WebApiContrib.Core/HttpRequestExtensions.cs
+++ b/src/WebApiContrib.Core/HttpRequestExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Microsoft.AspNetCore.Http;
+
+namespace WebApiContrib.Core
+{
+
+    public static class HttpRequestExtensions
+    {
+        public static bool IsAjaxRequest(this HttpRequest request)
+        {
+            if (request == null) throw new ArgumentNullException(nameof(request));
+
+            return (request.Headers != null) && (request.Headers["X-Requested-With"] == "XMLHttpRequest");
+        }
+    }
+}


### PR DESCRIPTION
same feature as traditionally used in ASP.NET.

`X-Requested-With` is not as widely used as in the past anymore, but should be a good enough base funcitonality