### PR TITLE
Closes #52

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -251,3 +251,4 @@ paket-files/
 # JetBrains Rider
 .idea/
 *.sln.iml
+/WebApiContrib.Core.Razor/Properties/launchSettings.json

--- a/WebApiContrib.Core.Razor/ServiceCollectionExtensions.cs
+++ b/WebApiContrib.Core.Razor/ServiceCollectionExtensions.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.AspNetCore.Razor.Runtime.TagHelpers;
+using Microsoft.Extensions.DependencyInjection;
+using WebApiContrib.Core.Razor.TagHelper;
+
+namespace WebApiContrib.Core.Razor
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static void EnableAddTagHelperAssemblyGlobbing(this IServiceCollection services)
+        {
+            services.AddSingleton<ITagHelperTypeResolver, AssemblyNameGlobbingTagHelperTypeResolver>();
+        }
+    }
+}

--- a/WebApiContrib.Core.Razor/TagHelper/AssemblyGlobbingTagHelperTypeResolver.cs
+++ b/WebApiContrib.Core.Razor/TagHelper/AssemblyGlobbingTagHelperTypeResolver.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Mvc.ApplicationParts;
+using Microsoft.AspNetCore.Mvc.Razor.TagHelpers;
+using Microsoft.AspNetCore.Razor;
+using Microsoft.AspNetCore.Razor.Runtime.TagHelpers;
+
+namespace WebApiContrib.Core.Razor.TagHelper
+{
+    public class AssemblyNameGlobbingTagHelperTypeResolver : ITagHelperTypeResolver
+    {
+        protected TagHelperFeature Feature { get; }
+
+        public AssemblyNameGlobbingTagHelperTypeResolver(ApplicationPartManager manager)
+        {
+            if (manager == null)
+            {
+                throw new ArgumentNullException(nameof(manager));
+            }
+
+            Feature = new TagHelperFeature();
+            manager.PopulateFeature(Feature);
+        }
+
+        public IEnumerable<Type> Resolve(
+            string name,
+            SourceLocation documentLocation,
+            ErrorSink errorSink)
+        {
+            if (errorSink == null)
+            {
+                throw new ArgumentNullException(nameof(errorSink));
+            }
+
+            if (string.IsNullOrEmpty(name))
+            {
+                var errorLength = name == null ? 1 : Math.Max(name.Length, 1);
+                errorSink.OnError(
+                    documentLocation,
+                    "Tag Helper Assembly Name Cannot Be Empty Or Null",
+                    errorLength);
+
+                return Type.EmptyTypes;
+            }
+
+
+            IEnumerable<TypeInfo> libraryTypes;
+            try
+            {
+                libraryTypes = GetExportedTypes(name);
+            }
+            catch (Exception ex)
+            {
+                errorSink.OnError(
+                    documentLocation,
+                    $"Cannot Resolve Tag Helper Assembly: {name}, {ex.Message}",
+                    name.Length);
+
+                return Type.EmptyTypes;
+            }
+
+            return libraryTypes.Select(a => a.AsType());
+
+        }
+
+        protected IEnumerable<System.Reflection.TypeInfo> GetExportedTypes(string assemblyNamePattern)
+        {
+            if (assemblyNamePattern == null)
+            {
+                throw new ArgumentNullException(nameof(assemblyNamePattern));
+            }
+
+            var results = new List<System.Reflection.TypeInfo>();
+            bool isGlobbingPattern = assemblyNamePattern.Contains("*");
+
+            for (var i = 0; i < Feature.TagHelpers.Count; i++)
+            {
+                var tagHelperAssemblyName = Feature.TagHelpers[i].Assembly.GetName();
+                if (isGlobbingPattern)
+                {
+                    if (MatchesGlob(tagHelperAssemblyName.Name, assemblyNamePattern))
+                    {
+                        results.Add(Feature.TagHelpers[i]);
+                        continue;
+                    }
+                }
+
+                // not a pattern so treat as normal assembly name.
+                var assyName = new AssemblyName(assemblyNamePattern);
+                if (AssemblyNameComparer.OrdinalIgnoreCase.Equals(tagHelperAssemblyName, assyName))
+                {
+                    results.Add(Feature.TagHelpers[i]);
+                    continue;
+                }
+            }
+
+            return results;
+        }
+
+        public static bool MatchesGlob(string evaluateString, string pattern)
+        {
+            return new Regex("^" + Regex.Escape(pattern).Replace(@"\*", ".*").Replace(@"\?", ".") + "$",
+                RegexOptions.IgnoreCase | RegexOptions.Singleline).IsMatch(evaluateString);
+        }
+
+        private class AssemblyNameComparer : IEqualityComparer<AssemblyName>
+        {
+            public static readonly IEqualityComparer<AssemblyName> OrdinalIgnoreCase = new AssemblyNameComparer();
+
+            private AssemblyNameComparer()
+            {
+            }
+
+            public bool Equals(AssemblyName x, AssemblyName y)
+            {
+                // Ignore case because that's what Assembly.Load does.
+                return string.Equals(x.Name, y.Name, StringComparison.OrdinalIgnoreCase) &&
+                       string.Equals(x.CultureName ?? string.Empty, y.CultureName ?? string.Empty, StringComparison.Ordinal);
+            }
+
+            public int GetHashCode(AssemblyName obj)
+            {
+                var hashCode = 0;
+                if (obj.Name != null)
+                {
+                    hashCode ^= obj.Name.GetHashCode();
+                }
+
+                hashCode ^= (obj.CultureName ?? string.Empty).GetHashCode();
+                return hashCode;
+            }
+        }
+
+    }
+}

--- a/WebApiContrib.Core.Razor/WebApiContrib.Core.Razor.xproj
+++ b/WebApiContrib.Core.Razor/WebApiContrib.Core.Razor.xproj
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>d3a1b8e8-c031-4212-a100-f43ea43e6d9b</ProjectGuid>
+    <RootNamespace>WebApiContrib.Core.Razor</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <DnxInvisibleContent Include="bower.json" />
+    <DnxInvisibleContent Include=".bowerrc" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\DotNet.Web\Microsoft.DotNet.Web.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/WebApiContrib.Core.Razor/project.json
+++ b/WebApiContrib.Core.Razor/project.json
@@ -1,0 +1,27 @@
+{
+  "description": "WebApiContrib.Core.Razor Class Library",
+  "dependencies": {
+    "Microsoft.AspNetCore.Mvc.Razor": "1.0.0",
+    "Microsoft.AspNetCore.Razor": "1.0.0",
+    "Microsoft.AspNetCore.Razor.Runtime": "1.0.0",
+    "Microsoft.Extensions.DependencyInjection.Abstractions": "1.0.0"
+  },
+  "packOptions": {
+    "tags": [ "" ],
+    "licenseUrl": "",
+    "projectUrl": ""
+  },
+  "tooling": {
+    "defaultNamespace": "WebApiContrib.Core.Razor"
+  },
+  "frameworks": {
+    "netstandard1.6": {
+      "imports": "dnxcore50"
+    },
+    "net451": {
+      "frameworkAssemblies": {
+        "System.Runtime": ""
+      }
+    }
+  }
+}

--- a/WebApiContrib.Core.sln
+++ b/WebApiContrib.Core.sln
@@ -49,6 +49,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "WebApiContrib.Core.WebPages
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "WebApiContrib.Core.WebPages.Samples", "samples\WebApiContrib.Core.WebPages.Samples\WebApiContrib.Core.WebPages.Samples.xproj", "{F9AE291E-A6BD-4F53-A73F-678FE0D5BF72}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "WebApiContrib.Core.Razor", "WebApiContrib.Core.Razor\WebApiContrib.Core.Razor.xproj", "{D3A1B8E8-C031-4212-A100-F43EA43E6D9B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -123,6 +125,10 @@ Global
 		{F9AE291E-A6BD-4F53-A73F-678FE0D5BF72}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F9AE291E-A6BD-4F53-A73F-678FE0D5BF72}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F9AE291E-A6BD-4F53-A73F-678FE0D5BF72}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D3A1B8E8-C031-4212-A100-F43EA43E6D9B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D3A1B8E8-C031-4212-A100-F43EA43E6D9B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D3A1B8E8-C031-4212-A100-F43EA43E6D9B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D3A1B8E8-C031-4212-A100-F43EA43E6D9B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -147,5 +153,6 @@ Global
 		{5A3DF1EA-4553-4370-8CD2-6C341CA80755} = {EDF687E4-3843-4FB0-9CDC-775E3594D384}
 		{720B3330-2C57-4D67-9D84-5DC76412F169} = {5898776F-DBF8-4C30-85A3-66401B12016F}
 		{F9AE291E-A6BD-4F53-A73F-678FE0D5BF72} = {EDF687E4-3843-4FB0-9CDC-775E3594D384}
+		{D3A1B8E8-C031-4212-A100-F43EA43E6D9B} = {5898776F-DBF8-4C30-85A3-66401B12016F}
 	EndGlobalSection
 EndGlobal

--- a/samples/WebApiContrib.Core.Samples/Controllers/AddTagHelperDirectiveController.cs
+++ b/samples/WebApiContrib.Core.Samples/Controllers/AddTagHelperDirectiveController.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Mvc;
+using WebApiContrib.Core.Samples.Model;
+
+namespace WebApiContrib.Core.Samples.Controllers
+{
+    [Route("[controller]")]
+    public class AddTagHelperDirectiveController : Controller
+    {
+        public IActionResult Sample()
+        {
+            return View();
+        }
+    }
+}

--- a/samples/WebApiContrib.Core.Samples/Startup.cs
+++ b/samples/WebApiContrib.Core.Samples/Startup.cs
@@ -7,6 +7,7 @@ using WebApiContrib.Core.Formatter.Csv;
 using WebApiContrib.Core.Formatter.Jsonp;
 using WebApiContrib.Core.Formatter.PlainText;
 using WebApiContrib.Core.Samples.Controllers;
+using WebApiContrib.Core.Razor;
 
 namespace WebApiContrib.Core.Samples
 {
@@ -29,9 +30,11 @@ namespace WebApiContrib.Core.Samples
             services.AddMvc(o =>
             {
                 o.AddJsonpOutputFormatter();
-                o.UseFromBodyBinding(controllerPredicate: c => c.ControllerType.AsType() == typeof(BindingController));
+                o.UseFromBodyBinding(controllerPredicate: c => c.ControllerType.AsType() == typeof (BindingController));
             }).AddCsvSerializerFormatters()
-              .AddPlainTextFormatters();
+                .AddPlainTextFormatters();
+
+            services.EnableAddTagHelperAssemblyGlobbing();
         }
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)

--- a/samples/WebApiContrib.Core.Samples/Views/AddTagHelperDirective/Sample.cshtml
+++ b/samples/WebApiContrib.Core.Samples/Views/AddTagHelperDirective/Sample.cshtml
@@ -1,0 +1,60 @@
+﻿@*Shows we can add tag helpers using a glob for assemblies.*@
+@addTagHelper "*, WebApiContrib.Core.TagHelpers.*"
+
+<md grid-tables="true">
+=======
+Sub-heading
+-----------
+### Another deeper heading
+
+Paragraphs are separated
+by a blank line.
+
+Two spaces at the end of a line leave a
+line break.
+
+Text attributes _italic_, *italic*, __bold__, **bold**, `monospace`.
+
+Horizontal rule:
+
+---
+
+Bullet list:
+
+* apples
+* oranges
+* pears
+
+Numbered list:
+
+1. apples
+2. oranges
+3. pears
+
+A [link](http://example.com).
+
+### Grid table
+
++---------+---------+
+| Header  | Header  |
+| Column1 | Column2 |
++=========+=========+
+| 1. ab   | Hello
+| 3. f    |
++---------+---------+
+| Second row spanning
+| on two columns
++---------+---------+
+| Back    |         |
+| to      |         |
+| one     |         |
+| column  |         | 
+</md>
+
+<md-extended>
+### Extended features: i.e. task lists
+ - [ ] Item1
+ - [x] Item2
+ - [ ] Item3
+ - Item4
+</md-extended>

--- a/samples/WebApiContrib.Core.Samples/project.json
+++ b/samples/WebApiContrib.Core.Samples/project.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "dependencies": {
     "Microsoft.NETCore.App": {
       "version": "1.0.0",
@@ -23,7 +23,8 @@
     "WebApiContrib.Core.Formatter.PlainText": "*",
     "WebApiContrib.Core.Formatter.Jsonp": "*",
     "WebApiContrib.Core.TagHelpers.Markdown": "*",
-    "WebApiContrib.Core": "*"
+    "WebApiContrib.Core": "*",
+    "WebApiContrib.Core.Razor": "1.0.0-*"
   },
 
   "tools": {


### PR DESCRIPTION
Created a new project for placing extensions to Razor.
Added a service that extends razor's `addTagHelper` directives, so you can use a globbing pattern on assembly names to match TagHelpers accross sets of assemblies.
Added a sample page to the core samples. Visit `/AddTagHelperDirective` to see the markdown tag helper working, thanks to the addTagHelper directive on the page that uses a glob pattern.
Interestingly I noticed the existing sample for markdown at `/Markdown/Sample` doesn't appear to be working - I haven't tried to fix it in this PR, because I like to keep things focused.