### PR TITLE
added RequiredFromQueryAttribute and RequiredFromQueryActionConstraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ WebAPIContrib.Core is a collection of open source projects, add-ons and extensio
 * [WebApiContrib.Core](https://github.com/WebApiContrib/WebAPIContrib.Core/tree/master/src/WebApiContrib.Core) [![Nuget](http://img.shields.io/nuget/v/WebApiContrib.Core.svg?maxAge=10800)](https://www.nuget.org/packages/WebApiContrib.Core/)
   * `GlobalRoutePrefixConvention` - `IApplicationModelConvention` allowing you to set a global route prefix, which is then combined into all actions
   * `FromBodyApplicationModelConvention` - `IApplicationModelConvention` allowing you to globally apply body binding source to action parameters. You can also provide predicates to filter on specific controllers, actions or parameters
+  * `RequiredFromQueryAttribute` allowing you to mark specific action parameters as mandatory query strings
   * `OverridableFilterProvider` - allows you to override filters from higher scope (i.e. global filters) on lower scope (i.e. controller filters)
   * `ValidationAttribute` - an action filter returning 400 response in case there are any model state errors
 

--- a/src/WebApiContrib.Core/Binding/RequiredFromQueryAttribute.cs
+++ b/src/WebApiContrib.Core/Binding/RequiredFromQueryAttribute.cs
@@ -1,0 +1,18 @@
+﻿using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
+using WebApiContrib.Core.Constraints;
+
+namespace WebApiContrib.Core.Binding
+{
+    public class RequiredFromQueryAttribute : FromQueryAttribute, IParameterModelConvention
+    {
+        public void Apply(ParameterModel parameter)
+        {
+            if (parameter.Action.Selectors != null && parameter.Action.Selectors.Any())
+            {
+                parameter.Action.Selectors.Last().ActionConstraints.Add(new RequiredFromQueryActionConstraint(parameter.BindingInfo?.BinderModelName ?? parameter.ParameterName));
+            }
+        }
+    }
+}

--- a/src/WebApiContrib.Core/Constraints/RequiredFromQueryActionConstraint.cs
+++ b/src/WebApiContrib.Core/Constraints/RequiredFromQueryActionConstraint.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.ActionConstraints;
+
+namespace WebApiContrib.Core.Constraints
+{
+    public class RequiredFromQueryActionConstraint : IActionConstraint
+    {
+        private readonly string _parameter;
+
+        public RequiredFromQueryActionConstraint(string parameter)
+        {
+            _parameter = parameter;
+        }
+
+        public int Order => 999;
+
+        public bool Accept(ActionConstraintContext context)
+        {
+            for (var i = 0; i < _parameter.Length; i++)
+            {
+                if (!context.RouteContext.HttpContext.Request.Query.ContainsKey(_parameter))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Usage:

```csharp
public class MyController : Controller
{
        [HttpGet("{id}")]
        public string Get(int id, [RequiredFromQuery]string foo, [RequiredFromQuery]string bar)
        {
            return "value " + foo + " " + bar;
        }
}
```

This action is only matched if the request contains `foo` and `bar` querystrings. 
Extends the default behavior of `[FromQuery]`, which treats parameters as optional.