### PR TITLE
allow global route prefix registration as string

### DIFF
--- a/src/WebApiContrib.Core/MvcOptionsExtensions.cs
+++ b/src/WebApiContrib.Core/MvcOptionsExtensions.cs
@@ -9,6 +9,11 @@ namespace WebApiContrib.Core
 {
     public static class MvcOptionsExtensions
     {
+        public static void UseGlobalRoutePrefix(this MvcOptions opts, string routeTemplate)
+        {
+            opts.Conventions.Insert(0, new GlobalRoutePrefixConvention(new RouteAttribute(routeTemplate)));
+        }
+
         public static void UseGlobalRoutePrefix(this MvcOptions opts, IRouteTemplateProvider routeAttribute)
         {
             opts.Conventions.Insert(0, new GlobalRoutePrefixConvention(routeAttribute));


### PR DESCRIPTION
`UseGlobalRoutePrefix("api")` vs `UseGlobalRoutePrefix(new RouteAttribute("api"))`