### PR TITLE
Added vary header support

### DIFF
--- a/samples/WebApiContrib.Core.Samples/Startup.cs
+++ b/samples/WebApiContrib.Core.Samples/Startup.cs
@@ -39,7 +39,6 @@ namespace WebApiContrib.Core.Samples
                 .AddPlainTextFormatters()
                 .AddVersionNegotiation(opt =>
                 {
-                    opt.EmitVaryHeader = true;
                     opt.UseAcceptHeaderParameterStrategy("apiVersion")
                         .UseAcceptHeaderFacetStrategy()
                         .UseRouteValueStrategy("version")

--- a/samples/WebApiContrib.Core.Samples/Startup.cs
+++ b/samples/WebApiContrib.Core.Samples/Startup.cs
@@ -32,16 +32,19 @@ namespace WebApiContrib.Core.Samples
             services.AddSingleton<IModelMapper<PersonModel>, PersonModelMapper>();
 
             services.AddMvc(o =>
-            {
-                o.AddJsonpOutputFormatter();
-                o.UseFromBodyBinding(controllerPredicate: c => c.ControllerType.AsType() == typeof (BindingController));
-            }).AddCsvSerializerFormatters()
+                {
+                    o.AddJsonpOutputFormatter();
+                    o.UseFromBodyBinding(controllerPredicate: c => c.ControllerType.AsType() == typeof(BindingController));
+                }).AddCsvSerializerFormatters()
                 .AddPlainTextFormatters()
-                .AddVersionNegotiation(x => x
-                    .UseAcceptHeaderParameterStrategy("apiVersion")
-                    .UseAcceptHeaderFacetStrategy()
-                    .UseRouteValueStrategy("version")
-                    .UseCustomHeaderStrategy("X-API-Version"));
+                .AddVersionNegotiation(opt =>
+                {
+                    opt.EmitVaryHeader = true;
+                    opt.UseAcceptHeaderParameterStrategy("apiVersion")
+                        .UseAcceptHeaderFacetStrategy()
+                        .UseRouteValueStrategy("version")
+                        .UseCustomHeaderStrategy("X-API-Version");
+                });
 
             services.EnableAddTagHelperAssemblyGlobbing();
         }

--- a/src/WebApiContrib.Core.Versioning/ParsingUtility.cs
+++ b/src/WebApiContrib.Core.Versioning/ParsingUtility.cs
@@ -2,11 +2,11 @@
 {
     internal static class ParsingUtility
     {
-        public static bool TryParseVersion(string value, out int? version)
+        public static bool TryParseVersion(string value, out int version)
         {
             if (string.IsNullOrEmpty(value))
             {
-                version = null;
+                version = 0;
                 return false;
             }
 
@@ -22,7 +22,7 @@
                 return true;
             }
 
-            version = null;
+            version = 0;
             return false;
         }
     }

--- a/src/WebApiContrib.Core.Versioning/Strategies/AcceptHeaderFacetVersionStrategy.cs
+++ b/src/WebApiContrib.Core.Versioning/Strategies/AcceptHeaderFacetVersionStrategy.cs
@@ -26,7 +26,7 @@ namespace WebApiContrib.Core.Versioning
                 return null;
             }
 
-            int? version;
+            int version;
             if (TryGetFacetVersion(subType, out version))
             {
                 return version;
@@ -35,7 +35,7 @@ namespace WebApiContrib.Core.Versioning
             return null;
         }
 
-        private static bool TryGetFacetVersion(string subType, out int? version)
+        private static bool TryGetFacetVersion(string subType, out int version)
         {
             var facetSeparatorIndex = subType.IndexOf('.');
 
@@ -52,7 +52,7 @@ namespace WebApiContrib.Core.Versioning
                 }
             }
 
-            version = null;
+            version = 0;
             return false;
         }
     }

--- a/src/WebApiContrib.Core.Versioning/Strategies/AcceptHeaderParameterVersionStrategy.cs
+++ b/src/WebApiContrib.Core.Versioning/Strategies/AcceptHeaderParameterVersionStrategy.cs
@@ -32,7 +32,7 @@ namespace WebApiContrib.Core.Versioning
                 return null;
             }
 
-            int? version;
+            int version;
             if (TryGetParameterVersion(acceptHeader, ParameterName, out version))
             {
                 return version;
@@ -41,7 +41,7 @@ namespace WebApiContrib.Core.Versioning
             return null;
         }
 
-        private static bool TryGetParameterVersion(MediaTypeHeaderValue acceptHeader, string parameterName, out int? version)
+        private static bool TryGetParameterVersion(MediaTypeHeaderValue acceptHeader, string parameterName, out int version)
         {
             foreach (var parameter in acceptHeader.Parameters)
             {
@@ -54,7 +54,7 @@ namespace WebApiContrib.Core.Versioning
                 }
             }
 
-            version = null;
+            version = 0;
             return false;
         }
     }

--- a/src/WebApiContrib.Core.Versioning/Strategies/AcceptHeaderVersionStrategy.cs
+++ b/src/WebApiContrib.Core.Versioning/Strategies/AcceptHeaderVersionStrategy.cs
@@ -12,7 +12,7 @@ namespace WebApiContrib.Core.Versioning
     public abstract class AcceptHeaderVersionStrategy : IVersionStrategy
     {
         /// <inheritdoc />
-        VersionContext IVersionStrategy.GetVersion(HttpContext context, RouteData routeData)
+        VersionResult? IVersionStrategy.GetVersion(HttpContext context, RouteData routeData)
         {
             if (context == null)
             {
@@ -34,7 +34,7 @@ namespace WebApiContrib.Core.Versioning
 
                 if (version.HasValue)
                 {
-                    return new VersionContext(version.Value, "Content-Type");
+                    return new VersionResult(version.Value, "Accept");
                 }
             }
 

--- a/src/WebApiContrib.Core.Versioning/Strategies/AcceptHeaderVersionStrategy.cs
+++ b/src/WebApiContrib.Core.Versioning/Strategies/AcceptHeaderVersionStrategy.cs
@@ -12,7 +12,7 @@ namespace WebApiContrib.Core.Versioning
     public abstract class AcceptHeaderVersionStrategy : IVersionStrategy
     {
         /// <inheritdoc />
-        int? IVersionStrategy.GetVersion(HttpContext context, RouteData routeData)
+        VersionContext IVersionStrategy.GetVersion(HttpContext context, RouteData routeData)
         {
             if (context == null)
             {
@@ -34,7 +34,7 @@ namespace WebApiContrib.Core.Versioning
 
                 if (version.HasValue)
                 {
-                    return version.Value;
+                    return new VersionContext(version.Value, "Content-Type");
                 }
             }
 

--- a/src/WebApiContrib.Core.Versioning/Strategies/CompositeVersionStrategy.cs
+++ b/src/WebApiContrib.Core.Versioning/Strategies/CompositeVersionStrategy.cs
@@ -13,13 +13,13 @@ namespace WebApiContrib.Core.Versioning
 
         private IEnumerable<IVersionStrategy> VersionStrategies { get; }
 
-        public int? GetVersion(HttpContext context, RouteData routeData)
+        public VersionContext GetVersion(HttpContext context, RouteData routeData)
         {
             foreach (var strategy in VersionStrategies)
             {
                 var version = strategy.GetVersion(context, routeData);
 
-                if (version.HasValue)
+                if (version != null)
                 {
                     return version;
                 }

--- a/src/WebApiContrib.Core.Versioning/Strategies/CompositeVersionStrategy.cs
+++ b/src/WebApiContrib.Core.Versioning/Strategies/CompositeVersionStrategy.cs
@@ -13,7 +13,7 @@ namespace WebApiContrib.Core.Versioning
 
         private IEnumerable<IVersionStrategy> VersionStrategies { get; }
 
-        public VersionContext GetVersion(HttpContext context, RouteData routeData)
+        public VersionResult? GetVersion(HttpContext context, RouteData routeData)
         {
             foreach (var strategy in VersionStrategies)
             {

--- a/src/WebApiContrib.Core.Versioning/Strategies/CompositeVersionStrategy.cs
+++ b/src/WebApiContrib.Core.Versioning/Strategies/CompositeVersionStrategy.cs
@@ -19,7 +19,7 @@ namespace WebApiContrib.Core.Versioning
             {
                 var version = strategy.GetVersion(context, routeData);
 
-                if (version != null)
+                if (version.HasValue)
                 {
                     return version;
                 }

--- a/src/WebApiContrib.Core.Versioning/Strategies/CustomHeaderVersionStrategy.cs
+++ b/src/WebApiContrib.Core.Versioning/Strategies/CustomHeaderVersionStrategy.cs
@@ -20,7 +20,7 @@ namespace WebApiContrib.Core.Versioning
         public string HeaderName { get; set; } = "Api-Version";
 
         /// <inheritdoc />
-        int? IVersionStrategy.GetVersion(HttpContext context, RouteData routeData)
+        VersionContext IVersionStrategy.GetVersion(HttpContext context, RouteData routeData)
         {
             if (context == null)
             {
@@ -35,7 +35,7 @@ namespace WebApiContrib.Core.Versioning
                 int? version;
                 if (ParsingUtility.TryParseVersion(header.ToString(), out version))
                 {
-                    return version;
+                    return new VersionContext(version, HeaderName); ;
                 }
             }
 

--- a/src/WebApiContrib.Core.Versioning/Strategies/CustomHeaderVersionStrategy.cs
+++ b/src/WebApiContrib.Core.Versioning/Strategies/CustomHeaderVersionStrategy.cs
@@ -20,7 +20,7 @@ namespace WebApiContrib.Core.Versioning
         public string HeaderName { get; set; } = "Api-Version";
 
         /// <inheritdoc />
-        VersionContext IVersionStrategy.GetVersion(HttpContext context, RouteData routeData)
+        VersionResult? IVersionStrategy.GetVersion(HttpContext context, RouteData routeData)
         {
             if (context == null)
             {
@@ -32,10 +32,10 @@ namespace WebApiContrib.Core.Versioning
             StringValues header;
             if (headers.TryGetValue(HeaderName, out header))
             {
-                int? version;
+                int version;
                 if (ParsingUtility.TryParseVersion(header.ToString(), out version))
                 {
-                    return new VersionContext(version, HeaderName); ;
+                    return new VersionResult(version, HeaderName); ;
                 }
             }
 

--- a/src/WebApiContrib.Core.Versioning/Strategies/IVersionStrategy.cs
+++ b/src/WebApiContrib.Core.Versioning/Strategies/IVersionStrategy.cs
@@ -15,6 +15,6 @@ namespace WebApiContrib.Core.Versioning
         /// <param name="context">The <see cref="HttpContext"/> of the current request.</param>
         /// <param name="routeData">The <see cref="RouteData"/>of the current request.</param>
         /// <returns>A version integer, or <c>null</c> if a version cannot be determined.</returns>
-        VersionContext GetVersion(HttpContext context, RouteData routeData);
+        VersionResult? GetVersion(HttpContext context, RouteData routeData);
     }
 }

--- a/src/WebApiContrib.Core.Versioning/Strategies/IVersionStrategy.cs
+++ b/src/WebApiContrib.Core.Versioning/Strategies/IVersionStrategy.cs
@@ -15,6 +15,6 @@ namespace WebApiContrib.Core.Versioning
         /// <param name="context">The <see cref="HttpContext"/> of the current request.</param>
         /// <param name="routeData">The <see cref="RouteData"/>of the current request.</param>
         /// <returns>A version integer, or <c>null</c> if a version cannot be determined.</returns>
-        int? GetVersion(HttpContext context, RouteData routeData);
+        VersionContext GetVersion(HttpContext context, RouteData routeData);
     }
 }

--- a/src/WebApiContrib.Core.Versioning/Strategies/RouteValueVersionStrategy.cs
+++ b/src/WebApiContrib.Core.Versioning/Strategies/RouteValueVersionStrategy.cs
@@ -13,7 +13,7 @@ namespace WebApiContrib.Core.Versioning
         public string RouteValueKey { get; set; } = "version";
 
         /// <inheritdoc />
-        int? IVersionStrategy.GetVersion(HttpContext context, RouteData routeData)
+        VersionContext IVersionStrategy.GetVersion(HttpContext context, RouteData routeData)
         {
             if (routeData == null)
             {
@@ -33,7 +33,7 @@ namespace WebApiContrib.Core.Versioning
             int? version;
             if (ParsingUtility.TryParseVersion(versionString, out version))
             {
-                return version;
+                return new VersionContext(version);
             }
 
             return null;

--- a/src/WebApiContrib.Core.Versioning/Strategies/RouteValueVersionStrategy.cs
+++ b/src/WebApiContrib.Core.Versioning/Strategies/RouteValueVersionStrategy.cs
@@ -13,7 +13,7 @@ namespace WebApiContrib.Core.Versioning
         public string RouteValueKey { get; set; } = "version";
 
         /// <inheritdoc />
-        VersionContext IVersionStrategy.GetVersion(HttpContext context, RouteData routeData)
+        VersionResult? IVersionStrategy.GetVersion(HttpContext context, RouteData routeData)
         {
             if (routeData == null)
             {
@@ -30,10 +30,10 @@ namespace WebApiContrib.Core.Versioning
 
             var versionString = versionObject as string;
 
-            int? version;
+            int version;
             if (ParsingUtility.TryParseVersion(versionString, out version))
             {
-                return new VersionContext(version);
+                return new VersionResult(version);
             }
 
             return null;

--- a/src/WebApiContrib.Core.Versioning/Strategies/VersionContext.cs
+++ b/src/WebApiContrib.Core.Versioning/Strategies/VersionContext.cs
@@ -1,15 +1,16 @@
 ﻿namespace WebApiContrib.Core.Versioning
 {
-    public class VersionContext
+    public struct VersionResult
     {
-        public int? Version { get; }
+        public int Version { get; }
+
         public string VaryOn { get; }
 
-        public VersionContext(int? version) : this(version, null)
+        public VersionResult(int version) : this(version, null)
         {
         }
 
-        public VersionContext(int? version, string varyOn)
+        public VersionResult(int version, string varyOn)
         {
             Version = version;
             VaryOn = varyOn;

--- a/src/WebApiContrib.Core.Versioning/Strategies/VersionContext.cs
+++ b/src/WebApiContrib.Core.Versioning/Strategies/VersionContext.cs
@@ -13,7 +13,7 @@
         public VersionResult(int version, string varyOn)
         {
             Version = version;
-            VaryOn = varyOn;
+            VaryOn = varyOn ?? string.Empty;
         }
     }
 }

--- a/src/WebApiContrib.Core.Versioning/Strategies/VersionContext.cs
+++ b/src/WebApiContrib.Core.Versioning/Strategies/VersionContext.cs
@@ -1,0 +1,18 @@
+﻿namespace WebApiContrib.Core.Versioning
+{
+    public class VersionContext
+    {
+        public int? Version { get; }
+        public string VaryOn { get; }
+
+        public VersionContext(int? version) : this(version, null)
+        {
+        }
+
+        public VersionContext(int? version, string varyOn)
+        {
+            Version = version;
+            VaryOn = varyOn;
+        }
+    }
+}

--- a/src/WebApiContrib.Core.Versioning/VersionNegotiationOptions.cs
+++ b/src/WebApiContrib.Core.Versioning/VersionNegotiationOptions.cs
@@ -15,7 +15,7 @@ namespace WebApiContrib.Core.Versioning
         {
             RequireVersionedObjectResult = true;
             ThrowOnMissingMapper = true;
-            EmitVaryHeader = false;
+            EmitVaryHeader = true;
             ConfigureStrategy = new Dictionary<Type, Action<object>>();
             StrategyTypes = new List<Type>();
         }
@@ -36,7 +36,7 @@ namespace WebApiContrib.Core.Versioning
         /// relevant for the applied versioning strategy
         /// </summary>
         /// <remarks>
-        /// The default is <c>false</c>.
+        /// The default is <c>true</c>.
         /// </remarks>
         public bool EmitVaryHeader { get; set; }
 

--- a/src/WebApiContrib.Core.Versioning/VersionNegotiationOptions.cs
+++ b/src/WebApiContrib.Core.Versioning/VersionNegotiationOptions.cs
@@ -16,6 +16,8 @@ namespace WebApiContrib.Core.Versioning
             RequireVersionedObjectResult = true;
             ThrowOnMissingMapper = true;
             EmitVaryHeader = false;
+            ConfigureStrategy = new Dictionary<Type, Action<object>>();
+            StrategyTypes = new List<Type>();
         }
 
         /// <summary>

--- a/src/WebApiContrib.Core.Versioning/VersionNegotiationOptions.cs
+++ b/src/WebApiContrib.Core.Versioning/VersionNegotiationOptions.cs
@@ -15,6 +15,7 @@ namespace WebApiContrib.Core.Versioning
         {
             RequireVersionedObjectResult = true;
             ThrowOnMissingMapper = true;
+            EmitVaryHeader = false;
         }
 
         /// <summary>
@@ -27,6 +28,15 @@ namespace WebApiContrib.Core.Versioning
         /// The default is <c>true</c>.
         /// </remarks>
         public bool RequireVersionedObjectResult { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether the response will contain a Vary HTTP header
+        /// relevant for the applied versioning strategy
+        /// </summary>
+        /// <remarks>
+        /// The default is <c>false</c>.
+        /// </remarks>
+        public bool EmitVaryHeader { get; set; }
 
         /// <summary>
         /// Gets or sets whether the version negotiation filter will throw a

--- a/src/WebApiContrib.Core.Versioning/VersionNegotiationResultFilter.cs
+++ b/src/WebApiContrib.Core.Versioning/VersionNegotiationResultFilter.cs
@@ -62,7 +62,7 @@ namespace WebApiContrib.Core.Versioning
             {
                 context.Result = MapResult(result, versionResult.Value.Version);
 
-                if (Options.Value.EmitVaryHeader && versionResult.Value.VaryOn != null)
+                if (Options.Value.EmitVaryHeader && !string.IsNullOrEmpty(versionResult.Value.VaryOn))
                 {
                     context.HttpContext.Response.Headers.Add("Vary", versionResult.Value.VaryOn);
                 }

--- a/src/WebApiContrib.Core.Versioning/VersionNegotiationResultFilter.cs
+++ b/src/WebApiContrib.Core.Versioning/VersionNegotiationResultFilter.cs
@@ -57,9 +57,16 @@ namespace WebApiContrib.Core.Versioning
 
             var strategy = ServiceProvider.GetRequiredService<IVersionStrategy>();
 
-            var version = strategy.GetVersion(context.HttpContext, context.RouteData);
+            var versionContext = strategy.GetVersion(context.HttpContext, context.RouteData);
+            if (versionContext?.Version != null)
+            {
+                context.Result = MapResult(result, versionContext.Version);
 
-            context.Result = MapResult(result, version);
+                if (Options.Value.EmitVaryHeader && versionContext.VaryOn != null)
+                {
+                    context.HttpContext.Response.Headers.Add("Vary", versionContext.VaryOn);
+                }
+            }
         }
 
         /// <inheritdoc />

--- a/src/WebApiContrib.Core.Versioning/VersionNegotiationResultFilter.cs
+++ b/src/WebApiContrib.Core.Versioning/VersionNegotiationResultFilter.cs
@@ -57,14 +57,14 @@ namespace WebApiContrib.Core.Versioning
 
             var strategy = ServiceProvider.GetRequiredService<IVersionStrategy>();
 
-            var versionContext = strategy.GetVersion(context.HttpContext, context.RouteData);
-            if (versionContext?.Version != null)
+            var versionResult = strategy.GetVersion(context.HttpContext, context.RouteData);
+            if (versionResult.HasValue)
             {
-                context.Result = MapResult(result, versionContext.Version);
+                context.Result = MapResult(result, versionResult.Value.Version);
 
-                if (Options.Value.EmitVaryHeader && versionContext.VaryOn != null)
+                if (Options.Value.EmitVaryHeader && versionResult.Value.VaryOn != null)
                 {
-                    context.HttpContext.Response.Headers.Add("Vary", versionContext.VaryOn);
+                    context.HttpContext.Response.Headers.Add("Vary", versionResult.Value.VaryOn);
                 }
             }
         }


### PR DESCRIPTION
 - fixed null references (missing dictionary/list initialization [here](https://github.com/WebApiContrib/WebAPIContrib.Core/pull/75/files#diff-37147d2d406ea191535381aee7361c01R19))
 - added support for emitting `Vary` header. 

For example

Request:
```
GET /api/versioned HTTP/1.1
X-API-Version: 2
```

Response:
```
Content-Type →application/json; charset=utf-8
Date →Fri, 30 Sep 2016 14:48:21 GMT
Server →Kestrel
Transfer-Encoding →chunked
Vary →X-API-Version
X-Powered-By →ASP.NET
```

cc @khellang 