### PR TITLE
Fixed bug where result wasn't being negotiated when version was missing

### DIFF
--- a/src/WebApiContrib.Core.Versioning/VersionNegotiationResultFilter.cs
+++ b/src/WebApiContrib.Core.Versioning/VersionNegotiationResultFilter.cs
@@ -58,14 +58,17 @@ namespace WebApiContrib.Core.Versioning
             var strategy = ServiceProvider.GetRequiredService<IVersionStrategy>();
 
             var versionResult = strategy.GetVersion(context.HttpContext, context.RouteData);
-            if (versionResult.HasValue)
-            {
-                context.Result = MapResult(result, versionResult.Value.Version);
 
-                if (Options.Value.EmitVaryHeader && !string.IsNullOrEmpty(versionResult.Value.VaryOn))
-                {
-                    context.HttpContext.Response.Headers.Add("Vary", versionResult.Value.VaryOn);
-                }
+            context.Result = MapResult(result, versionResult?.Version);
+
+            if (!versionResult.HasValue)
+            {
+                return;
+            }
+
+            if (Options.Value.EmitVaryHeader && !string.IsNullOrEmpty(versionResult.Value.VaryOn))
+            {
+                context.HttpContext.Response.Headers.Add("Vary", versionResult.Value.VaryOn);
             }
         }
 


### PR DESCRIPTION
The `HasValue` check resulted in skipping the negotiation when the strategy didn't return a result. In that case, the negotiation should still be called, but with a `null` version, so it can return the default model.