### PR TITLE
[DoNotMerge] BranchWithServices: Failing test for resolving IHttpContextAccessor

### DIFF
--- a/WebApiContrib.Core.sln
+++ b/WebApiContrib.Core.sln
@@ -46,6 +46,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebApiContrib.Core.Formatte
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebApiContrib.Core.Yaml.Tests", "tests\WebApiContrib.Core.Yaml.Tests\WebApiContrib.Core.Yaml.Tests.csproj", "{3EC99E77-9F1E-4D43-B70B-E67C61D7E8DB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApiContrib.Core.Tests", "tests\WebApiContrib.Core.Tests\WebApiContrib.Core.Tests\WebApiContrib.Core.Tests.csproj", "{95BBC107-ABC5-4C5B-A51D-559741A4DC8B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -124,6 +126,10 @@ Global
 		{3EC99E77-9F1E-4D43-B70B-E67C61D7E8DB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3EC99E77-9F1E-4D43-B70B-E67C61D7E8DB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3EC99E77-9F1E-4D43-B70B-E67C61D7E8DB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{95BBC107-ABC5-4C5B-A51D-559741A4DC8B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{95BBC107-ABC5-4C5B-A51D-559741A4DC8B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{95BBC107-ABC5-4C5B-A51D-559741A4DC8B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{95BBC107-ABC5-4C5B-A51D-559741A4DC8B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -148,6 +154,7 @@ Global
 		{DA5532DB-81C4-4F39-B6F2-164ECA46292B} = {A7A8D928-30D6-4497-8B7D-F233B79A2917}
 		{D542971E-D9D3-4E8F-A4BF-D1638D7C2613} = {5898776F-DBF8-4C30-85A3-66401B12016F}
 		{3EC99E77-9F1E-4D43-B70B-E67C61D7E8DB} = {A7A8D928-30D6-4497-8B7D-F233B79A2917}
+		{95BBC107-ABC5-4C5B-A51D-559741A4DC8B} = {A7A8D928-30D6-4497-8B7D-F233B79A2917}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C1758983-E7A8-4669-9176-F46E7A08E588}

--- a/tests/WebApiContrib.Core.Tests/WebApiContrib.Core.Tests/ParallelApplicationPipelinesExtensionsTests.cs
+++ b/tests/WebApiContrib.Core.Tests/WebApiContrib.Core.Tests/ParallelApplicationPipelinesExtensionsTests.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Internal;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Azure.KeyVault;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.WindowsAzure.Storage.Blob.Protocol;
+using Xunit;
+
+namespace WebApiContrib.Core.Tests
+{
+    public class ParallelApplicationPipelinesExtensionsTests
+    {
+        [Fact]
+        public async Task HttpContextAccessor_Not_Null()
+        {
+            var webHostBuilder = new WebHostBuilder()
+                .UseEnvironment("Development")
+                .UseStartup<Startup>();
+
+            var testServer = new TestServer(webHostBuilder);
+
+            var client = testServer.CreateClient();
+
+            var response = await client.GetAsync("/path");
+
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        public class Startup
+        {
+            public void ConfigureServices(IServiceCollection services)
+            {}
+
+            public void Configure(IApplicationBuilder app)
+            {
+                app.UseBranchWithServices("/path",
+                    services =>
+                    {
+                        services.AddSingleton<Service>();
+                    },
+                    pathApp =>
+                    {
+                        pathApp.UseMiddleware<Middleware>();
+                    });
+            }
+        }
+
+        public class Service
+        {
+            private readonly IHttpContextAccessor _httpContextAccessor;
+
+            public Service(IHttpContextAccessor httpContextAccessor)
+            {
+                _httpContextAccessor = httpContextAccessor;
+            }
+        }
+
+        public class Middleware
+        {
+            private readonly RequestDelegate _next;
+            private readonly Service _service;
+
+            public Middleware(RequestDelegate next, Service service)
+            {
+                _next = next;
+                _service = service;
+            }
+
+            public async Task Invoke(HttpContext httpContext)
+            {
+                await _next(httpContext);
+            }
+        }
+    }
+}

--- a/tests/WebApiContrib.Core.Tests/WebApiContrib.Core.Tests/ParallelApplicationPipelinesExtensionsTests.cs
+++ b/tests/WebApiContrib.Core.Tests/WebApiContrib.Core.Tests/ParallelApplicationPipelinesExtensionsTests.cs
@@ -1,14 +1,10 @@
-﻿using System;
-using System.Net;
+﻿using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Hosting.Internal;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
-using Microsoft.Azure.KeyVault;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.WindowsAzure.Storage.Blob.Protocol;
 using Xunit;
 
 namespace WebApiContrib.Core.Tests

--- a/tests/WebApiContrib.Core.Tests/WebApiContrib.Core.Tests/ParallelApplicationPipelinesExtensionsTests.cs
+++ b/tests/WebApiContrib.Core.Tests/WebApiContrib.Core.Tests/ParallelApplicationPipelinesExtensionsTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -29,7 +30,14 @@ namespace WebApiContrib.Core.Tests
 
         public class Startup
         {
-            public void ConfigureServices(IServiceCollection services)
+            private readonly IServiceProvider _serviceProvider;
+
+            public Startup(IServiceProvider serviceProvider)
+            {
+                _serviceProvider = serviceProvider;
+            }
+
+            public void ConfigureServices()
             {}
 
             public void Configure(IApplicationBuilder app)
@@ -38,6 +46,9 @@ namespace WebApiContrib.Core.Tests
                     services =>
                     {
                         services.AddSingleton<Service>();
+                        // Uncommenting the line below makes the test pass. However are there
+                        // side effects? What else needs to be passed through?
+                        // services.AddSingleton(_ =>_serviceProvider.GetService<IHttpContextAccessor>());
                     },
                     pathApp =>
                     {

--- a/tests/WebApiContrib.Core.Tests/WebApiContrib.Core.Tests/WebApiContrib.Core.Tests.csproj
+++ b/tests/WebApiContrib.Core.Tests/WebApiContrib.Core.Tests/WebApiContrib.Core.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\WebApiContrib.Core\WebApiContrib.Core.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Been exploring `UseBranchWithServices` and not entirely sure am doing it write. Here I added a test project for WebApiContrib.Core and failing test to show resolution of a service failing. Discovered this when attempting to use Identity Server in a branch and was getting ANEs and NREs from deep within it. 

It's not clear whether one should be passing the IHttpContextAccessor into the branch's container. And if one should, what else is missing?

```
Application startup exception: System.InvalidOperationException: Unable to resolve service for type 'Microsoft.AspNetCore.Http.IHttpContextAccessor' while attempting to activate 'WebApiContrib.Core.Tests.ParallelApplicationPipelinesExtensionsTests+Service'.
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.CreateArgumentCallSites(Type serviceType, Type implementationType, ISet`1 callSiteChain, ParameterInfo[] parameters, Boolean throwIfCallSiteNotFound)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.CreateConstructorCallSite(Type serviceType, Type implementationType, ISet`1 callSiteChain)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.TryCreateExact(ServiceDescriptor descriptor, Type serviceType, ISet`1 callSiteChain)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.TryCreateExact(Type serviceType, ISet`1 callSiteChain)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.CreateCallSite(Type serviceType, ISet`1 callSiteChain)
   at Microsoft.Extensions.DependencyInjection.ServiceProvider.CreateServiceAccessor(Type serviceType, ServiceProvider serviceProvider)
   at System.Collections.Concurrent.ConcurrentDictionaryExtensions.GetOrAdd[TKey,TValue,TArg](ConcurrentDictionary`2 dictionary, TKey key, Func`3 valueFactory, TArg arg)
   at Microsoft.Extensions.DependencyInjection.ServiceProvider.GetService(Type serviceType)
   at Microsoft.Extensions.Internal.ActivatorUtilities.ConstructorMatcher.CreateInstance(IServiceProvider provider)
   at Microsoft.Extensions.Internal.ActivatorUtilities.CreateInstance(IServiceProvider provider, Type instanceType, Object[] parameters)
   at Microsoft.AspNetCore.Builder.UseMiddlewareExtensions.<>c__DisplayClass4_0.<UseMiddleware>b__0(RequestDelegate next)
   at Microsoft.AspNetCore.Builder.Internal.ApplicationBuilder.Build()
   at WebApiContrib.Core.ParallelApplicationPipelinesExtensions.UseBranchWithServices(IApplicationBuilder app, PathString path, Action`1 servicesConfiguration, Action`1 appBuilderConfiguration) in E:\dev\damianh\WebAPIContrib.Core\src\WebApiContrib.Core\ParallelApplicationPipelinesExtensions.cs:line 46
   at WebApiContrib.Core.Tests.ParallelApplicationPipelinesExtensionsTests.Startup.Configure(IApplicationBuilder app) in E:\dev\damianh\WebAPIContrib.Core\tests\WebApiContrib.Core.Tests\WebApiContrib.Core.Tests\ParallelApplicationPipelinesExtensionsTests.cs:line 41
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at Microsoft.AspNetCore.Hosting.ConventionBasedStartup.Configure(IApplicationBuilder app)
   at Microsoft.AspNetCore.Hosting.Internal.AutoRequestServicesStartupFilter.<>c__DisplayClass0_0.<Configure>b__0(IApplicationBuilder builder)
   at Microsoft.AspNetCore.Hosting.Internal.WebHost.BuildApplication()
System.InvalidOperationException: Unable to resolve service for type 'Microsoft.AspNetCore.Http.IHttpContextAccessor' while attempting to activate 'WebApiContrib.Core.Tests.ParallelApplicationPipelinesExtensionsTests+Service'.
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.CreateArgumentCallSites(Type serviceType, Type implementationType, ISet`1 callSiteChain, ParameterInfo[] parameters, Boolean throwIfCallSiteNotFound)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.CreateConstructorCallSite(Type serviceType, Type implementationType, ISet`1 callSiteChain)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.TryCreateExact(ServiceDescriptor descriptor, Type serviceType, ISet`1 callSiteChain)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.TryCreateExact(Type serviceType, ISet`1 callSiteChain)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.CreateCallSite(Type serviceType, ISet`1 callSiteChain)
   at Microsoft.Extensions.DependencyInjection.ServiceProvider.CreateServiceAccessor(Type serviceType, ServiceProvider serviceProvider)
   at System.Collections.Concurrent.ConcurrentDictionaryExtensions.GetOrAdd[TKey,TValue,TArg](ConcurrentDictionary`2 dictionary, TKey key, Func`3 valueFactory, TArg arg)
   at Microsoft.Extensions.DependencyInjection.ServiceProvider.GetService(Type serviceType)
   at Microsoft.Extensions.Internal.ActivatorUtilities.ConstructorMatcher.CreateInstance(IServiceProvider provider)
   at Microsoft.Extensions.Internal.ActivatorUtilities.CreateInstance(IServiceProvider provider, Type instanceType, Object[] parameters)
   at Microsoft.AspNetCore.Builder.UseMiddlewareExtensions.<>c__DisplayClass4_0.<UseMiddleware>b__0(RequestDelegate next)
   at Microsoft.AspNetCore.Builder.Internal.ApplicationBuilder.Build()
   at WebApiContrib.Core.ParallelApplicationPipelinesExtensions.UseBranchWithServices(IApplicationBuilder app, PathString path, Action`1 servicesConfiguration, Action`1 appBuilderConfiguration) in E:\dev\damianh\WebAPIContrib.Core\src\WebApiContrib.Core\ParallelApplicationPipelinesExtensions.cs:line 46
   at WebApiContrib.Core.Tests.ParallelApplicationPipelinesExtensionsTests.Startup.Configure(IApplicationBuilder app) in E:\dev\damianh\WebAPIContrib.Core\tests\WebApiContrib.Core.Tests\WebApiContrib.Core.Tests\ParallelApplicationPipelinesExtensionsTests.cs:line 41
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at Microsoft.AspNetCore.Hosting.ConventionBasedStartup.Configure(IApplicationBuilder app)
   at Microsoft.AspNetCore.Hosting.Internal.AutoRequestServicesStartupFilter.<>c__DisplayClass0_0.<Configure>b__0(IApplicationBuilder builder)
   at Microsoft.AspNetCore.Hosting.Internal.WebHost.BuildApplication()
   at Microsoft.AspNetCore.Hosting.WebHostBuilder.Build()
   at Microsoft.AspNetCore.TestHost.TestServer..ctor(IWebHostBuilder builder, IFeatureCollection featureCollection)
   at WebApiContrib.Core.Tests.ParallelApplicationPipelinesExtensionsTests.<HttpContextAccessor_Not_Null>d__0.MoveNext() in E:\dev\damianh\WebAPIContrib.Core\tests\WebApiContrib.Core.Tests\WebApiContrib.Core.Tests\ParallelApplicationPipelinesExtensionsTests.cs:line 25
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Xunit.Sdk.TestInvoker`1.<>c__DisplayClass48_1.<<InvokeTestMethodAsync>b__1>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Xunit.Sdk.ExecutionTimer.<AggregateAsync>d__4.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Xunit.Sdk.ExceptionAggregator.<RunAsync>d__9.MoveNext()

```