### PR TITLE
Allow tab to be used as CSVDelimiter and  Excel Delimiter Header

### DIFF
--- a/src/WebApiContrib.Core.Formatter.Csv/CsvFormatterMvcBuilderExtensions.cs
+++ b/src/WebApiContrib.Core.Formatter.Csv/CsvFormatterMvcBuilderExtensions.cs
@@ -30,7 +30,7 @@ namespace WebApiContrib.Core.Formatter.Csv
                 csvFormatterOptions = new CsvFormatterOptions();
             }
 
-            if (string.IsNullOrWhiteSpace(csvFormatterOptions.CsvDelimiter))
+            if (string.IsNullOrEmpty(csvFormatterOptions.CsvDelimiter))
             {
                 throw new ArgumentException("CsvDelimiter cannot be empty");
             }

--- a/src/WebApiContrib.Core.Formatter.Csv/CsvFormatterOptions.cs
+++ b/src/WebApiContrib.Core.Formatter.Csv/CsvFormatterOptions.cs
@@ -7,5 +7,7 @@
         public string CsvDelimiter { get; set; } = ";";
 
         public string Encoding { get; set; } = "ISO-8859-1";
+
+        public bool IncludeExcelDelimiterHeader { get; set; } = false;
     }
 }

--- a/src/WebApiContrib.Core.Formatter.Csv/CsvOutputFormatter.cs
+++ b/src/WebApiContrib.Core.Formatter.Csv/CsvOutputFormatter.cs
@@ -87,6 +87,11 @@ namespace WebApiContrib.Core.Formatter.Csv
 
             var streamWriter = new StreamWriter(response.Body, Encoding.GetEncoding(_options.Encoding));
 
+            if (_options.IncludeExcelDelimiterHeader)
+            {
+                await streamWriter.WriteLineAsync($"sep ={_options.CsvDelimiter}");
+            }
+
             if (_options.UseSingleLineHeaderInCsv)
             {
                 var values = useJsonAttributes

--- a/src/WebApiContrib.Core.Formatter.Csv/README.md
+++ b/src/WebApiContrib.Core.Formatter.Csv/README.md
@@ -124,13 +124,16 @@ The formatters can be added to the ASP.NET Core project in the Startup class in 
 
 The default delimiter is set to ';' and the header is included by default.
 
+Optionally setting IncludeExcelDelimiterHeader to true adds the "sep=,"  header, so the files can be opened in Excel directly.
+
 ```csharp
 public void ConfigureServices(IServiceCollection services)
 {
 	//var csvOptions = new CsvFormatterOptions
 	//{
 	//    UseSingleLineHeaderInCsv = true,
-	//    CsvDelimiter = ","
+	//    CsvDelimiter = ",",
+	//    IncludeExcelDelimiterHeader = true
 	//};
 
 	//services.AddMvc()


### PR DESCRIPTION
1.  Allow tab to be used as CSVDelimiter
2. Option to include Excel Delimiter Header, allowing the downloaded file to be opened in excel directly.