### PR TITLE
Support for IHttpContextAccessor in ParallelApplicationPipelinesExtensions

### DIFF
--- a/src/WebApiContrib.Core/ParallelApplicationPipelinesExtensions.cs
+++ b/src/WebApiContrib.Core/ParallelApplicationPipelinesExtensions.cs
@@ -37,6 +37,13 @@ namespace WebApiContrib.Core
                 using (var scope = factory.CreateScope())
                 {
                     context.RequestServices = scope.ServiceProvider;
+                    
+                    var httpContextAccessor = context.RequestServices
+                                                     .GetService<IHttpContextAccessor>();
+
+                    if (httpContextAccessor != null)
+                        httpContextAccessor.HttpContext = context;
+                    
                     await next();
                 }
             });


### PR DESCRIPTION
`ParallelApplicationPipelinesExtensions` is great, but lacks support for `IHttpContextAccessor`, so it's not possible to inject `HttpContext` into services. Here's a quick fix.

Also, I am thinking about adding a support for custom `IServiceProvider` (like `Autofac`  for example). For now, it's impossible because you use some dummy `Startup` class.