### PR TITLE
Added correct usage of CanRead/CanReadType.

### DIFF
--- a/src/WebApiContrib.Core.Formatter.Csv/CsvInputFormatter.cs
+++ b/src/WebApiContrib.Core.Formatter.Csv/CsvInputFormatter.cs
@@ -45,9 +45,8 @@ namespace WebApiContrib.Core.Formatter.Csv
             return InputFormatterResult.SuccessAsync(result);
         }
 
-        public override bool CanRead(InputFormatterContext context)
+        protected override bool CanReadType(Type type)
         {
-            var type = context.ModelType;
             if (type == null)
                 throw new ArgumentNullException("type");
 
@@ -127,7 +126,7 @@ namespace WebApiContrib.Core.Formatter.Csv
                 }
                 return array;
             }
-            
+
             return list;
         }
     }

--- a/src/WebApiContrib.Core.Formatter.MessagePack/MessagePackInputFormatter.cs
+++ b/src/WebApiContrib.Core.Formatter.MessagePack/MessagePackInputFormatter.cs
@@ -49,19 +49,14 @@ namespace WebApiContrib.Core.Formatter.MessagePack
             return formatterResult;
         }
 
-        public override bool CanRead(InputFormatterContext context)
+        protected override bool CanReadType(Type type)
         {
-            if (context == null)
+            if (type == null)
             {
-                throw new ArgumentNullException(nameof(context));
+                throw new ArgumentException("Type cannot be null");
             }
 
-            if (context.ModelType == null)
-            {
-                throw new ArgumentException("Model Type cannnot be null");
-            }
-
-            var typeInfo = context.ModelType.GetTypeInfo();
+            var typeInfo = type.GetTypeInfo();
             return !typeInfo.IsAbstract && !typeInfo.IsInterface && typeInfo.IsPublic;
         }
     }

--- a/src/WebApiContrib.Core.Formatter.Protobuf/ProtobufInputFormatter.cs
+++ b/src/WebApiContrib.Core.Formatter.Protobuf/ProtobufInputFormatter.cs
@@ -38,7 +38,7 @@ namespace WebApiContrib.Core.Formatter.Protobuf
             return InputFormatterResult.SuccessAsync(result);
         }
 
-        public override bool CanRead(InputFormatterContext context)
+        protected override bool CanReadType(Type type)
         {
             return true;
         }

--- a/src/WebApiContrib.Core.Formatter.Yaml/YamlInputFormatter.cs
+++ b/src/WebApiContrib.Core.Formatter.Yaml/YamlInputFormatter.cs
@@ -32,7 +32,7 @@ namespace WebApiContrib.Core.Formatter.Yaml
             }
         }
 
-        public override bool CanRead(InputFormatterContext context)
+        protected override bool CanReadType(Type type)
         {
             return true;
         }

--- a/tests/WebApiContrib.Core.MessagePack.Tests/MessagePackTests.cs
+++ b/tests/WebApiContrib.Core.MessagePack.Tests/MessagePackTests.cs
@@ -73,6 +73,7 @@ namespace WebApiContrib.Core.MessagePack.Tests
             };
 
             request.Content = new ByteArrayContent(MessagePackSerializer.Serialize<Book>(book, ContractlessStandardResolver.Instance));
+            request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/x-msgpack");
             var result = await client.SendAsync(request);
 
             var echo = MessagePackSerializer.Deserialize<Book>(await result.Content.ReadAsStreamAsync(), ContractlessStandardResolver.Instance);

--- a/tests/WebApiContrib.Core.Protobuf.Tests/ProtobufTests.cs
+++ b/tests/WebApiContrib.Core.Protobuf.Tests/ProtobufTests.cs
@@ -134,6 +134,7 @@ namespace WebApiContrib.Core.Protobuf.Tests
             ProtoBuf.Serializer.Serialize<Book>(stream, book);
 
             HttpContent data = new StreamContent(stream);
+            data.Headers.ContentType = new MediaTypeHeaderValue("application/x-protobuf");
 
             request.Content = data;
             var result = await client.SendAsync(request);
@@ -163,6 +164,7 @@ namespace WebApiContrib.Core.Protobuf.Tests
             ProtoBuf.Serializer.Serialize<Book>(stream, book);
 
             HttpContent data = new StreamContent(stream);
+            data.Headers.ContentType = new MediaTypeHeaderValue("application/protobuf");
 
             request.Content = data;
             var result = await client.SendAsync(request);
@@ -192,6 +194,7 @@ namespace WebApiContrib.Core.Protobuf.Tests
             ProtoBuf.Serializer.Serialize<Book>(stream, book);
 
             HttpContent data = new StreamContent(stream);
+            data.Headers.ContentType = new MediaTypeHeaderValue("application/x-google-protobuf");
 
             request.Content = data;
             var result = await client.SendAsync(request);

--- a/tests/WebApiContrib.Core.Yaml.Tests/YamlTests.cs
+++ b/tests/WebApiContrib.Core.Yaml.Tests/YamlTests.cs
@@ -170,6 +170,7 @@ namespace WebApiContrib.Core.Yaml.Tests
             writer.Flush();
 
             HttpContent data = new StreamContent(stream);
+            data.Headers.ContentType = new MediaTypeHeaderValue("application/x-yaml");
 
             request.Content = data;
             var result = await client.SendAsync(request);
@@ -201,6 +202,7 @@ namespace WebApiContrib.Core.Yaml.Tests
             writer.Flush();
 
             HttpContent data = new StreamContent(stream);
+            data.Headers.ContentType = new MediaTypeHeaderValue("application/yaml");
 
             request.Content = data;
             var result = await client.SendAsync(request);
@@ -232,6 +234,7 @@ namespace WebApiContrib.Core.Yaml.Tests
             writer.Flush();
 
             HttpContent data = new StreamContent(stream);
+            data.Headers.ContentType = new MediaTypeHeaderValue("text/yaml");
 
             request.Content = data;
             var result = await client.SendAsync(request);
@@ -263,6 +266,7 @@ namespace WebApiContrib.Core.Yaml.Tests
             writer.Flush();
 
             HttpContent data = new StreamContent(stream);
+            data.Headers.ContentType = new MediaTypeHeaderValue("text/x-yaml");
 
             request.Content = data;
             var result = await client.SendAsync(request);
@@ -273,7 +277,7 @@ namespace WebApiContrib.Core.Yaml.Tests
             Assert.Equal(book.Author, echo.Author);
             Assert.Equal(book.Title, echo.Title);
         }
-        
+
         [Fact]
         public async Task GetCollection_JSON_Header()
         {


### PR DESCRIPTION
Issue: ASP.Net MVC unable to choose right formatter from the set added for configured content types because of CanRead methods overrides logic with filtering by SupportedMediaTypes.
Fix: Input formatters should use default implementation of CanRead method to do right matching by Content-Type header. CanRead was replaced with CanReadType.