### PR TITLE
CsvOutputFormatter now accepts IEnumerable

### DIFF
--- a/src/WebApiContrib.Core.Formatter.Csv/CsvOutputFormatter.cs
+++ b/src/WebApiContrib.Core.Formatter.Csv/CsvOutputFormatter.cs
@@ -43,15 +43,10 @@ namespace WebApiContrib.Core.Formatter.Csv
 
         private bool IsTypeOfIEnumerable(Type type)
         {
-
-            foreach (Type interfaceType in type.GetInterfaces())
-            {
-
-                if (interfaceType == typeof(IList))
-                    return true;
-            }
-
-            return false;
+            if (type == null)
+                throw new ArgumentNullException("type");
+            
+            return typeof(IEnumerable).IsAssignableFrom(type);
         }
 
         /// <summary>


### PR DESCRIPTION
CsvOutputFormatter doesn't process CSV if the input type is IEnumerable. It currently accepts only IList. Is there a good reason for this? I've made a copy on my project and using this version instead.