### PR TITLE
Fixed bug in removing trailing delimiter

### DIFF
--- a/src/WebApiContrib.Core.Formatter.Csv/CsvOutputFormatter.cs
+++ b/src/WebApiContrib.Core.Formatter.Csv/CsvOutputFormatter.cs
@@ -149,7 +149,7 @@ namespace WebApiContrib.Core.Formatter.Csv
                     }
                 }
 
-                await streamWriter.WriteLineAsync(valueLine.TrimEnd(_options.CsvDelimiter.ToCharArray()));
+                await streamWriter.WriteLineAsync(valueLine.Remove(valueLine.Length - _options.CsvDelimiter.Length));
             }
 
             await streamWriter.FlushAsync();


### PR DESCRIPTION
The existing code strips all trailing delimiters which is incorrect, it should only remove the final delimiter.  The problem occurs when the last column is empty.  Say you export three fields, first name, last name & email (where email is null).  Expected output would be "John;Doe;" but instead you get "John;Doe" which is problematic.