### PR TITLE
Make ReadStream public.

### DIFF
--- a/src/WebApiContrib.Core.Formatter.Csv/CsvInputFormatter.cs
+++ b/src/WebApiContrib.Core.Formatter.Csv/CsvInputFormatter.cs
@@ -66,7 +66,7 @@ namespace WebApiContrib.Core.Formatter.Csv
             return false;
         }
 
-        private object ReadStream(Type type, Stream stream)
+        public object ReadStream(Type type, Stream stream)
         {
             Type itemType;
             var typeIsArray = false;


### PR DESCRIPTION
I need to manually call `ReadStream` in my unit tests to convert a CSV stream back into a type so I can assert values and whatnot. Currently I am trying to wrap the `CsvInputFormatter` in a [RestEase](https://github.com/canton7/RestEase/) `ResponseDeserializer`.