### PR TITLE
allow configuring multiple routes to a single isolated application branch

### DIFF
--- a/WebApiContrib.Core.sln
+++ b/WebApiContrib.Core.sln
@@ -44,6 +44,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebApiContrib.Core.Formatte
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebApiContrib.Core.Yaml.Tests", "tests\WebApiContrib.Core.Yaml.Tests\WebApiContrib.Core.Yaml.Tests.csproj", "{3EC99E77-9F1E-4D43-B70B-E67C61D7E8DB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApiContrib.Core.Tests", "tests\WebApiContrib.Core.Tests\WebApiContrib.Core.Tests.csproj", "{6466DD2D-6358-4D7F-8562-2517F7F53E3F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -118,6 +120,10 @@ Global
 		{3EC99E77-9F1E-4D43-B70B-E67C61D7E8DB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3EC99E77-9F1E-4D43-B70B-E67C61D7E8DB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3EC99E77-9F1E-4D43-B70B-E67C61D7E8DB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6466DD2D-6358-4D7F-8562-2517F7F53E3F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6466DD2D-6358-4D7F-8562-2517F7F53E3F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6466DD2D-6358-4D7F-8562-2517F7F53E3F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6466DD2D-6358-4D7F-8562-2517F7F53E3F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -141,6 +147,7 @@ Global
 		{DA5532DB-81C4-4F39-B6F2-164ECA46292B} = {A7A8D928-30D6-4497-8B7D-F233B79A2917}
 		{D542971E-D9D3-4E8F-A4BF-D1638D7C2613} = {5898776F-DBF8-4C30-85A3-66401B12016F}
 		{3EC99E77-9F1E-4D43-B70B-E67C61D7E8DB} = {A7A8D928-30D6-4497-8B7D-F233B79A2917}
+		{6466DD2D-6358-4D7F-8562-2517F7F53E3F} = {A7A8D928-30D6-4497-8B7D-F233B79A2917}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C1758983-E7A8-4669-9176-F46E7A08E588}

--- a/build.fsx
+++ b/build.fsx
@@ -30,6 +30,7 @@ Target "Pack" (fun _ ->
 
 "Clean"
       ==> "Build"
+      ==> "Test"
       ==> "Pack"
 
 RunTargetOrDefault "Pack"

--- a/src/WebApiContrib.Core/WebApiContrib.Core.csproj
+++ b/src/WebApiContrib.Core/WebApiContrib.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Community Contributions for ASP.NET Core. Add-ons and extensions to help improve your work with ASP.NET Core and ASP.NET Core MVC.</Description>
-    <VersionPrefix>2.1.0</VersionPrefix>
+    <VersionPrefix>2.1.1</VersionPrefix>
     <Authors>filipw;WebApiContrib Contributors</Authors>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>WebApiContrib.Core</AssemblyName>

--- a/tests/WebApiContrib.Core.Tests/ParallelPipelinesTests.cs
+++ b/tests/WebApiContrib.Core.Tests/ParallelPipelinesTests.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace WebApiContrib.Core.Tests
+{
+    public class ParallelPipelinesTests
+    {
+        private TestServer _server;
+
+        public ParallelPipelinesTests()
+        {
+            _server = new TestServer(new WebHostBuilder()
+                    .UseContentRoot(Directory.GetCurrentDirectory())
+                    .UseStartup<Startup>());
+        }
+
+        [Theory]
+        [InlineData("foo")]
+        [InlineData("bar")]
+        public async Task CanReachBranch(string path)
+        {
+            var client = _server.CreateClient();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, $"/{path}");
+            var result = await client.SendAsync(request);
+            var stringResult = await result.Content.ReadAsStringAsync();
+
+            Assert.Equal($"hi {path}", stringResult);
+        }
+
+        [Theory]
+        [InlineData("foo1")]
+        [InlineData("foo2")]
+        [InlineData("bar1")]
+        [InlineData("bar2")]
+        public async Task CanReachBranchWithMultipleEntryPoints(string path)
+        {
+            var client = _server.CreateClient();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, $"/{path}");
+            var result = await client.SendAsync(request);
+            var stringResult = await result.Content.ReadAsStringAsync();
+
+            Assert.Equal($"hi {path.Substring(0, path.Length-1)}", stringResult);
+        }
+    }
+}

--- a/tests/WebApiContrib.Core.Tests/Startup.cs
+++ b/tests/WebApiContrib.Core.Tests/Startup.cs
@@ -1,0 +1,92 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Http;
+
+namespace WebApiContrib.Core.Tests
+{
+    public interface IService
+    {
+        string Hi();
+    }
+
+    public class FooService : IService
+    {
+        public string Hi() => "hi foo";
+    }
+
+    public class BarService : IService
+    {
+        public string Hi() => "hi bar";
+    }
+
+    public class Startup
+    {
+        public IConfigurationRoot Configuration { get; }
+
+        public Startup(IHostingEnvironment env)
+        {
+            var builder = new ConfigurationBuilder()
+                .SetBasePath(env.ContentRootPath)
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                .AddEnvironmentVariables();
+            Configuration = builder.Build();
+        }
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+        }
+
+        public void Configure(IApplicationBuilder app)
+        {
+            app.UseBranchWithServices("/foo", s =>
+            {
+                s.AddTransient<IService, FooService>();
+            }, a =>
+            {
+                a.Use(async (c, next) =>
+                {
+                    var service = c.RequestServices.GetRequiredService<IService>();
+                    await c.Response.WriteAsync(service.Hi());
+                });
+            });
+
+            app.UseBranchWithServices("/bar", s =>
+            {
+                s.AddTransient<IService, BarService>();
+            }, a =>
+            {
+                a.Use(async (c, next) =>
+                {
+                    var service = c.RequestServices.GetRequiredService<IService>();
+                    await c.Response.WriteAsync(service.Hi());
+                });
+            });
+
+            app.UseBranchWithServices(new PathString[] { "/foo1", "/foo2" }, s =>
+            {
+                s.AddTransient<IService, FooService>();
+            }, a =>
+            {
+                a.Use(async (c, next) =>
+                {
+                    var service = c.RequestServices.GetRequiredService<IService>();
+                    await c.Response.WriteAsync(service.Hi());
+                });
+            });
+
+            app.UseBranchWithServices(new PathString[] { "/bar1", "/bar2" }, s =>
+            {
+                s.AddTransient<IService, BarService>();
+            }, a =>
+            {
+                a.Use(async (c, next) =>
+                {
+                    var service = c.RequestServices.GetRequiredService<IService>();
+                    await c.Response.WriteAsync(service.Hi());
+                });
+            });
+        }
+    }
+}

--- a/tests/WebApiContrib.Core.Tests/WebApiContrib.Core.Tests.csproj
+++ b/tests/WebApiContrib.Core.Tests/WebApiContrib.Core.Tests.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MessagePack" Version="1.7.3.4" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\WebApiContrib.Core\WebApiContrib.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Instead of having just one route to your application branch, you can have many entry points if you wish - there is still just a single container shared between them.