### PR TITLE
CSV Replace smart quotes when encoding is Windows-1252

### DIFF
--- a/src/WebApiContrib.Core.Formatter.Csv/CsvOutputFormatter.cs
+++ b/src/WebApiContrib.Core.Formatter.Csv/CsvOutputFormatter.cs
@@ -127,6 +127,10 @@ namespace WebApiContrib.Core.Formatter.Csv
 
                         var _val = val.Value.ToString();
 
+                        //Substitute smart quotes in Windows-1252
+                        if (_options.Encoding.EncodingName == "Western European (ISO)")
+                            _val = _val.Replace('“', '"').Replace('”', '"');
+
                         //Escape quotes
                         _val = _val.Replace("\"", "\"\"");
 


### PR DESCRIPTION
For the CSV output formatter when the encoding is set to `ISO-8859-1` [smart quotes](https://devblogs.microsoft.com/oldnewthing/20090225-00/?p=19033) are translated [to a regular quote](https://stackoverflow.com/questions/34040740/which-double-quote-characters-are-automatically-replaced-when-converting-from-ut) which then doesn't get escaped in the output.

For example `James “Mad Dog” Mattis` is output as `James "Mad Dog" Mattis` instead of `James ""Mad Dog"" Mattis`.