### PR TITLE
[PR] The proj files have been updated to enable SourceLink

### DIFF
--- a/src/WebApiContrib.Core.Formatter.Jsonp/WebApiContrib.Core.Formatter.Jsonp.csproj
+++ b/src/WebApiContrib.Core.Formatter.Jsonp/WebApiContrib.Core.Formatter.Jsonp.csproj
@@ -9,7 +9,15 @@
     <PackageTags>ASP.NET Core;webapicontrib;jsonp;aspnetcore;formatter</PackageTags>
     <PackageProjectUrl>https://github.com/WebApiContrib/WebAPIContrib.Core/tree/master/src/WebApiContrib.Core.Formatter.Jsonp</PackageProjectUrl>
     <Version>2.1.0</Version>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.3" />

--- a/src/WebApiContrib.Core.Formatter.MessagePack/WebApiContrib.Core.Formatter.MessagePack.csproj
+++ b/src/WebApiContrib.Core.Formatter.MessagePack/WebApiContrib.Core.Formatter.MessagePack.csproj
@@ -9,7 +9,15 @@
     <PackageId>WebApiContrib.Core.Formatter.MessagePack</PackageId>
     <PackageTags>ASP.NET Core;InputFormatter;OutputFormatter;MediaFormatter;MessagePack;Content-Type;aspnetcore</PackageTags>
     <PackageProjectUrl>https://github.com/WebAPIContrib/WebAPIContrib.Core/tree/master/src/WebApiContrib.Core.Formatter.MessagePack</PackageProjectUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.3" />

--- a/src/WebApiContrib.Core.Formatter.PlainText/WebApiContrib.Core.Formatter.PlainText.csproj
+++ b/src/WebApiContrib.Core.Formatter.PlainText/WebApiContrib.Core.Formatter.PlainText.csproj
@@ -9,7 +9,15 @@
     <PackageTags>ASP.NET Core;webapicontrib;plain text;text;aspnetcore;formatter</PackageTags>
     <PackageProjectUrl>https://github.com/WebApiContrib/WebAPIContrib.Core/tree/master/src/WebApiContrib.Core.Formatter.PlainText</PackageProjectUrl>
     <Version>2.1.0</Version>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.3" />

--- a/src/WebApiContrib.Core.Formatter.Yaml/WebApiContrib.Core.Formatter.Yaml.csproj
+++ b/src/WebApiContrib.Core.Formatter.Yaml/WebApiContrib.Core.Formatter.Yaml.csproj
@@ -9,7 +9,15 @@
     <PackageId>WebApiContrib.Core.Formatter.Yaml</PackageId>
     <PackageTags>ASP.NET Core;InputFormatter;OutputFormatter;MediaFormatter;Yaml;Content-Type;aspnetcore</PackageTags>
     <PackageProjectUrl>https://github.com/WebAPIContrib/WebAPIContrib.Core/tree/master/src/WebApiContrib.Core.Formatter.Yaml</PackageProjectUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.3" />

--- a/src/WebApiContrib.Core.TagHelpers.Markdown/WebApiContrib.Core.TagHelpers.Markdown.csproj
+++ b/src/WebApiContrib.Core.TagHelpers.Markdown/WebApiContrib.Core.TagHelpers.Markdown.csproj
@@ -9,7 +9,15 @@
     <PackageId>WebApiContrib.Core.TagHelpers.Markdown</PackageId>
     <PackageTags>ASP.NET Core;webapicontrib;markdown;razor;aspnetcore</PackageTags>
     <PackageProjectUrl>https://github.com/WebApiContrib/WebAPIContrib.Core/tree/master/src/WebApiContrib.Core.TagHelpers.Markdown</PackageProjectUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <Content Include="markdig-license.txt">


### PR DESCRIPTION
CSProj files have been updated to enable SourceLink in your nuget
---

*[This pull request was created with an automated workflow]*

I noticed that your repository and Nuget package are important for our .NET community, but you still haven't enabled SourceLink.

**We have to take 2 steps:**
1) Please approve this pull request and make .NET a better place for .NET developers and their debugging.
2) **Then just upload the .snupkg file** to https://www.nuget.org/ (now you can find the snupkg file along with the .nuget file)

You can find more information about SourceLine at the following links  
https://github.com/dotnet/sourcelink
https://www.hanselman.com/blog/ExploringNETCoresSourceLinkSteppingIntoTheSourceCodeOfNuGetPackagesYouDontOwn.aspx

If you are interesting about this automated workflow and how it works  
https://github.com/JTOne123/GitHubMassUpdater

*If you notice any flaws, please comment and I will try to make fixes manually*
