### PR TITLE
Add Support for Header Translation

### DIFF
--- a/src/WebApiContrib.Core.Formatter.Csv/CsvOutputFormatter.cs
+++ b/src/WebApiContrib.Core.Formatter.Csv/CsvOutputFormatter.cs
@@ -61,7 +61,7 @@ namespace WebApiContrib.Core.Formatter.Csv
                 return value;
             }
 
-            return pi.GetCustomAttribute<DisplayAttribute>(false)?.Name ?? pi.Name;
+            return pi.GetCustomAttribute<DisplayAttribute>(false)?.GetName() ?? pi.Name;
         }
 
         public async override Task WriteResponseBodyAsync(OutputFormatterWriteContext context)


### PR DESCRIPTION
Updated to use DisplayAttribute.GetName() instead of DisplayAttribute.Name to support translation through a resource file