### PR TITLE
Fixed issue where errorHandler in BsonInputFormatter is voked multitple times

### DIFF
--- a/src/WebApiContrib.Core.Formatter.Bson/BsonInputFormatter.cs
+++ b/src/WebApiContrib.Core.Formatter.Bson/BsonInputFormatter.cs
@@ -57,6 +57,7 @@ namespace WebApiContrib.Core.Formatter.Bson
                 }
                 finally
                 {
+                    jsonSerializer.Error -= errorHandler;
                     _jsonSerializerPool.Return(jsonSerializer);
                 }
 


### PR DESCRIPTION
`CreateJsonSerializer()` may return a serializer that was previously returned to the pool. This means this serializer's `Error` event already have a subscriber. If we try to add more subscribers (`jsonSerializer.Error += errorHandler;`), the `errorHandler` will be invoked multiple times when the serializer fail to `Deserialize`. Therefore, we need to remove the subscriber before returning the serializer to the pool.